### PR TITLE
refactor(web): 解耦命令处理与事件映射

### DIFF
--- a/agent/channel.py
+++ b/agent/channel.py
@@ -1,4 +1,4 @@
-"""WebSocket 帧与 BeanAgent 消息/事件总线之间的 Web 通道。"""
+"""WebSocket 生命周期与传输无关命令/事件之间的适配通道。"""
 
 from __future__ import annotations
 
@@ -8,9 +8,7 @@ import weakref
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, Protocol
-from uuid import uuid4
 
-from agent.agent_loop import InterruptResult
 from agent.event_bus import (
     ContextCompactionCompleted,
     ContextCompactionFailed,
@@ -26,7 +24,14 @@ from agent.event_bus import (
     TurnQueueRejected,
     TurnStarted,
 )
-from agent.message_bus import InboundMessage, MessageBus, OutboundMessage
+from agent.message_bus import MessageBus, OutboundMessage
+from agent.web_commands import (
+    InterruptController,
+    WebCommandError,
+    WebCommandService,
+    normalize_web_session_id,
+)
+from agent.web_events import MappedWebEvent, WebEventMapper, WebLifecycleEvent
 from proactive.notification_service import notification_metadata
 from proactive.store import ProactiveStore
 
@@ -39,8 +44,20 @@ class WebSocketApi(Protocol):
     async def send_json(self, data: dict[str, Any]) -> None: ...
 
 
-class InterruptController(Protocol):
-    async def request_interrupt(self, session_key: str) -> InterruptResult: ...
+_WEB_EVENT_TYPES = (
+    TurnStarted,
+    ContextCompactionStarted,
+    ContextCompactionCompleted,
+    ContextCompactionFailed,
+    ContextUsageUpdated,
+    SessionUsageUpdated,
+    SessionUpdated,
+    TurnQueued,
+    TurnQueueRejected,
+    StreamDeltaReady,
+    ToolCallStarted,
+    ToolCallCompleted,
+)
 
 
 class WebChannel:
@@ -61,10 +78,14 @@ class WebChannel:
     ) -> None:
         self._bus = bus
         self._events = event_bus
-        self._interrupt = interrupt_controller
-        self._media_root = media_root.resolve() if media_root is not None else None
+        self._commands = WebCommandService(
+            bus,
+            interrupt_controller,
+            media_root=media_root,
+            ensure_session=ensure_session,
+        )
+        self._mapper = WebEventMapper()
         self._proactive_store = proactive_store
-        self._ensure_session = ensure_session
         self._context_usage_loader = context_usage_loader
         self._session_usage_loader = session_usage_loader
         self._context_runtime_id = str(context_runtime_id or "")
@@ -74,18 +95,8 @@ class WebChannel:
         )
         self._lock = asyncio.Lock()
         bus.subscribe_outbound(self.name, self._on_response)
-        event_bus.on(TurnStarted, self._on_turn_started)
-        event_bus.on(ContextCompactionStarted, self._on_context_compaction_started)
-        event_bus.on(ContextCompactionCompleted, self._on_context_compaction_completed)
-        event_bus.on(ContextCompactionFailed, self._on_context_compaction_failed)
-        event_bus.on(ContextUsageUpdated, self._on_context_usage_updated)
-        event_bus.on(SessionUsageUpdated, self._on_session_usage_updated)
-        event_bus.on(SessionUpdated, self._on_session_updated)
-        event_bus.on(TurnQueued, self._on_turn_queued)
-        event_bus.on(TurnQueueRejected, self._on_turn_queue_rejected)
-        event_bus.on(StreamDeltaReady, self._on_stream_delta)
-        event_bus.on(ToolCallStarted, self._on_tool_started)
-        event_bus.on(ToolCallCompleted, self._on_tool_completed)
+        for event_type in _WEB_EVENT_TYPES:
+            event_bus.on(event_type, self._on_event)
 
     async def handle_websocket(self, websocket: WebSocketApi) -> None:
         await websocket.accept()
@@ -106,10 +117,15 @@ class WebChannel:
             await self._send_json(websocket, {"type": "pong", "request_id": request_id})
             return
         if frame_type == "session.create":
-            session_key = await self._create_session()
+            session_key = await self._commands.create_session()
             await self._register(session_key, websocket)
-            await self._send_json(websocket, {"type": "session.created", "request_id": request_id, "session_id": session_key})
+            await self._send_json(websocket, {
+                "type": "session.created",
+                "request_id": request_id,
+                "session_id": session_key,
+            })
             return
+
         session_key = normalize_web_session_id(frame.get("session_id"))
         if frame_type == "session.subscribe" and session_key is not None:
             await self._register(session_key, websocket)
@@ -125,73 +141,59 @@ class WebChannel:
             await self._replay_pending_notifications(session_key, websocket)
             return
         if frame_type == "message.send":
-            text = str(frame.get("text") or "")
-            media = [str(item).strip() for item in frame.get("media", []) if isinstance(item, str) and str(item).strip()] if isinstance(frame.get("media"), list) else []
-            if not text.strip() and not media:
-                await self._error(websocket, request_id, "empty_message", "消息不能为空")
+            try:
+                prepared = await self._commands.prepare_message(
+                    request_id=request_id,
+                    session_id=frame.get("session_id"),
+                    text=frame.get("text"),
+                    media=frame.get("media", []),
+                )
+            except WebCommandError as error:
+                await self._error(websocket, request_id, error.code, error.message)
                 return
-            if len(text) > 32 * 1024 or len(media) > 8:
-                await self._error(websocket, request_id, "message_too_large", "消息或媒体数量超过限制")
-                return
-            if not self._media_is_allowed(media):
-                await self._error(websocket, request_id, "invalid_media", "附件路径无效或不属于当前 workspace")
-                return
-            if session_key is None:
-                session_key = await self._create_session()
-                await self._send_json(websocket, {"type": "session.created", "request_id": request_id, "session_id": session_key})
-            await self._register(session_key, websocket)
-            chat_id = session_key.split(":", 1)[1]
-            await self._bus.publish_inbound(InboundMessage(self.name, "web", chat_id, text, list(media), {"request_id": request_id}))
+
+            # 发布可能同步触发 Turn 事件，因此连接注册和新会话确认必须先完成。
+            await self._register(prepared.session_key, websocket)
+            if prepared.created_session:
+                await self._send_json(websocket, {
+                    "type": "session.created",
+                    "request_id": request_id,
+                    "session_id": prepared.session_key,
+                })
+            await self._commands.submit_message(prepared)
             return
         if frame_type == "turn.stop" and session_key is not None:
-            result = await self._interrupt.request_interrupt(session_key)
-            await self._send_json(websocket, {
-                "type": "turn.interrupted",
-                "request_id": request_id,
-                "session_id": session_key,
-                "turn_id": result.turn_id,
-                "status": result.status,
-                **({"duration_ms": result.duration_ms} if result.duration_ms is not None else {}),
-                **({"ended_at": result.ended_at} if result.ended_at else {}),
-            })
+            result = await self._commands.stop_turn(session_key)
+            await self._send_mapped(
+                websocket,
+                self._mapper.map_interrupted(session_key, request_id, result),
+            )
             return
-        await self._error(websocket, request_id, "invalid_frame", f"不支持的帧类型: {frame_type or 'empty'}")
-
-    async def _create_session(self) -> str:
-        """创建 Web 会话并先持久化空元数据，保证随后 HTTP 查询不会短暂返回 404。"""
-
-        session_key = f"web:{uuid4().hex}"
-        if self._ensure_session is not None:
-            await self._ensure_session(session_key)
-        return session_key
-
-    def _media_is_allowed(self, media: list[str]) -> bool:
-        if not media or self._media_root is None:
-            return True
-        for value in media:
-            try:
-                path = Path(value).expanduser().resolve()
-                path.relative_to(self._media_root)
-            except (OSError, ValueError):
-                return False
-            if not path.is_file():
-                return False
-        return True
+        await self._error(
+            websocket,
+            request_id,
+            "invalid_frame",
+            f"不支持的帧类型: {frame_type or 'empty'}",
+        )
 
     async def _on_response(self, message: OutboundMessage) -> None:
-        session_key = f"{message.channel}:{message.chat_id}"
-        metadata = dict(message.metadata)
-        sent = await self._broadcast(session_key, {
-            "type": "message.final", "request_id": str(message.metadata.get("request_id") or ""),
-            "session_id": session_key, "turn_id": str(message.metadata.get("turn_id") or ""),
-            "content": message.content, "thinking": message.thinking, "media": list(message.media),
-            "message_id": str(metadata.get("message_id") or ""), "metadata": metadata,
-        })
-        notification_id = str(metadata.get("notification_id") or "")
+        mapped = self._mapper.map_outbound(message)
+        sent = await self._broadcast_mapped(mapped)
+        notification_id = str(message.metadata.get("notification_id") or "")
         if sent and notification_id and self._proactive_store is not None:
-            await asyncio.to_thread(self._proactive_store.mark_notification_delivered, notification_id)
+            await asyncio.to_thread(
+                self._proactive_store.mark_notification_delivered,
+                notification_id,
+            )
 
-    async def _replay_pending_notifications(self, session_key: str, websocket: WebSocketApi) -> None:
+    async def _on_event(self, event: WebLifecycleEvent) -> None:
+        await self._broadcast_mapped(self._mapper.map_event(event))
+
+    async def _replay_pending_notifications(
+        self,
+        session_key: str,
+        websocket: WebSocketApi,
+    ) -> None:
         """订阅会话时补发离线通知；失败时保持 pending，供下一次连接重试。"""
 
         if self._proactive_store is None:
@@ -203,37 +205,45 @@ class WebChannel:
         )
         for item in items:
             try:
+                mapped = self._mapper.map_pending_notification(
+                    session_key,
+                    content=item.content,
+                    message_id=item.id,
+                    metadata=notification_metadata(item),
+                )
+
                 async def send() -> None:
-                    await self._send_json(websocket, {
-                        "type": "message.final",
-                        "request_id": "",
-                        "session_id": session_key,
-                        "turn_id": "",
-                        "content": item.content,
-                        "thinking": "",
-                        "media": [],
-                        "message_id": item.id,
-                        "metadata": notification_metadata(item),
-                    })
+                    await self._send_mapped(websocket, mapped)
 
                 channel, chat_id = session_key.split(":", 1)
                 await self._bus.chat_lane.run_non_passive(channel, chat_id, send)
             except Exception:
                 return
-            await asyncio.to_thread(self._proactive_store.mark_notification_delivered, item.id)
+            await asyncio.to_thread(
+                self._proactive_store.mark_notification_delivered,
+                item.id,
+            )
 
-    async def _send_active_turn_snapshot(self, session_key: str, websocket: WebSocketApi) -> None:
-        """从 AgentLoop 读取纯内存 running turn 快照，避免刷新后前端丢失正在生成的内容。"""
+    async def _send_active_turn_snapshot(
+        self,
+        session_key: str,
+        websocket: WebSocketApi,
+    ) -> None:
+        """只向新订阅连接恢复 AgentLoop 中尚未持久化的运行快照。"""
 
-        snapshotter = getattr(self._interrupt, "get_active_turn_snapshot", None)
-        if not callable(snapshotter):
+        snapshot = self._commands.get_active_turn_snapshot(session_key)
+        if snapshot is None:
             return
-        snapshot = snapshotter(session_key)
-        if not snapshot:
-            return
-        await self._send_json(websocket, {"type": "turn.snapshot", **dict(snapshot)})
+        await self._send_mapped(
+            websocket,
+            self._mapper.map_active_turn_snapshot(session_key, snapshot),
+        )
 
-    async def _send_context_usage_snapshot(self, session_key: str, websocket: WebSocketApi) -> None:
+    async def _send_context_usage_snapshot(
+        self,
+        session_key: str,
+        websocket: WebSocketApi,
+    ) -> None:
         """订阅时恢复与当前模型身份匹配的计量快照。"""
 
         if self._context_usage_loader is None:
@@ -242,39 +252,41 @@ class WebChannel:
             snapshot = await self._context_usage_loader(session_key)
         except Exception as error:
             logger.warning("读取 Web 上下文计量快照失败 session=%s error=%s", session_key, error)
-            await self._send_json(websocket, {
-                "type": "context.usage.reset",
-                "session_id": session_key,
-            })
+            await self._send_mapped(
+                websocket,
+                self._mapper.map_context_usage_reset(session_key),
+            )
             return
         if not isinstance(snapshot, dict):
-            await self._send_json(websocket, {
-                "type": "context.usage.reset",
-                "session_id": session_key,
-            })
+            await self._send_mapped(
+                websocket,
+                self._mapper.map_context_usage_reset(session_key),
+            )
             return
         runtime_id = str(snapshot.get("model_runtime_id") or "")
         if self._context_runtime_id and runtime_id and runtime_id != self._context_runtime_id:
             # 模型切换后的旧 pressure 不得与新容量合并；等新模型返回 usage。
-            await self._send_json(websocket, {
-                "type": "context.usage.reset",
-                "session_id": session_key,
-            })
+            await self._send_mapped(
+                websocket,
+                self._mapper.map_context_usage_reset(session_key),
+            )
             return
         if snapshot.get("pressure_tokens") is None:
-            await self._send_json(websocket, {
-                "type": "context.usage.reset",
-                "session_id": session_key,
-            })
+            await self._send_mapped(
+                websocket,
+                self._mapper.map_context_usage_reset(session_key),
+            )
             return
-        await self._send_json(websocket, {
-            "type": "context.usage.updated",
-            "session_id": session_key,
-            "turn_id": "",
-            **_context_usage_frame(snapshot),
-        })
+        await self._send_mapped(
+            websocket,
+            self._mapper.map_context_usage_snapshot(session_key, snapshot),
+        )
 
-    async def _send_session_usage_snapshot(self, session_key: str, websocket: WebSocketApi) -> None:
+    async def _send_session_usage_snapshot(
+        self,
+        session_key: str,
+        websocket: WebSocketApi,
+    ) -> None:
         """订阅时恢复底栏累计用量；没有真实调用记录则保持隐藏。"""
 
         if self._session_usage_loader is None:
@@ -285,125 +297,10 @@ class WebChannel:
             logger.warning("读取会话累计用量失败 session=%s error=%s", session_key, error)
             return
         if isinstance(usage, dict):
-            await self._send_json(websocket, {
-                "type": "session.usage.updated",
-                "session_id": session_key,
-                "turn_id": "",
-                **_session_usage_frame(usage),
-            })
-
-    async def _on_turn_started(self, event: TurnStarted) -> None:
-        await self._broadcast(event.session_key, {"type": "turn.started", "request_id": event.request_id, "session_id": event.session_key, "turn_id": event.turn_id})
-
-    async def _on_context_compaction_started(self, event: ContextCompactionStarted) -> None:
-        await self._broadcast(event.session_key, {
-            "type": "context.compaction.started",
-            "session_id": event.session_key,
-            "turn_id": event.turn_id,
-            "trigger": event.trigger,
-            "estimated_tokens": event.estimated_tokens,
-        })
-
-    async def _on_context_compaction_completed(self, event: ContextCompactionCompleted) -> None:
-        await self._broadcast(event.session_key, {
-            "type": "context.compaction.completed",
-            "session_id": event.session_key,
-            "turn_id": event.turn_id,
-            "trigger": event.trigger,
-            "estimated_tokens": event.estimated_tokens,
-            "compacted": event.compacted,
-        })
-
-    async def _on_context_compaction_failed(self, event: ContextCompactionFailed) -> None:
-        await self._broadcast(event.session_key, {
-            "type": "context.compaction.failed",
-            "session_id": event.session_key,
-            "turn_id": event.turn_id,
-            "trigger": event.trigger,
-            "estimated_tokens": event.estimated_tokens,
-            "message": event.error,
-        })
-
-    async def _on_context_usage_updated(self, event: ContextUsageUpdated) -> None:
-        frame = {
-            "type": "context.usage.updated",
-            "session_id": event.session_key,
-            "turn_id": event.turn_id,
-            "used_tokens": event.used_tokens,
-            "context_window": event.context_window,
-            "soft_limit_tokens": event.soft_limit_tokens,
-            "hard_input_tokens": event.hard_input_tokens,
-            "context_window_source": event.context_window_source,
-            "estimate_source": event.estimate_source,
-            "breakdown": dict(event.breakdown),
-            "sections": [dict(section) for section in event.sections],
-        }
-        optional = {
-            "pressure_tokens": event.pressure_tokens,
-            "projected_tokens": event.projected_tokens,
-            "surface_tokens": event.surface_tokens,
-            "system_tokens": event.system_tokens,
-            "tools_tokens": event.tools_tokens,
-            "message_tokens": event.message_tokens,
-            "as_of_seq": event.as_of_seq,
-            "model_runtime_id": event.model_runtime_id,
-            "model": event.model,
-        }
-        frame.update({key: value for key, value in optional.items() if value is not None})
-        await self._broadcast(event.session_key, frame)
-
-    async def _on_session_usage_updated(self, event: SessionUsageUpdated) -> None:
-        await self._broadcast(event.session_key, {
-            "type": "session.usage.updated",
-            "session_id": event.session_key,
-            "turn_id": event.turn_id,
-            "total_uncached_input_tokens": event.total_uncached_input_tokens,
-            "total_cache_read_tokens": event.total_cache_read_tokens,
-            "total_cache_write_tokens": event.total_cache_write_tokens,
-            "total_input_tokens": event.total_input_tokens,
-            "cache_hit_rate": event.cache_hit_rate,
-            "total_output_tokens": event.total_output_tokens,
-        })
-
-    async def _on_session_updated(self, event: SessionUpdated) -> None:
-        await self._broadcast(event.session_key, {
-            "type": "session.updated",
-            "session": dict(event.session),
-        })
-
-    async def _on_turn_queued(self, event: TurnQueued) -> None:
-        await self._broadcast(event.session_key, {
-            "type": "turn.queued",
-            "request_id": event.request_id,
-            "session_id": event.session_key,
-            "position": event.position,
-        })
-
-    async def _on_turn_queue_rejected(self, event: TurnQueueRejected) -> None:
-        messages = {
-            "queue_full": "当前任务较多，请稍后再试",
-            "session_busy": "当前会话正在处理消息",
-            "closed": "服务正在关闭，请稍后再试",
-        }
-        await self._broadcast(event.session_key, {
-            "type": "error",
-            "request_id": event.request_id,
-            "session_id": event.session_key,
-            "code": event.reason,
-            "message": messages.get(event.reason, "消息暂时无法处理"),
-        })
-
-    async def _on_stream_delta(self, event: StreamDeltaReady) -> None:
-        if event.content_delta:
-            await self._broadcast(event.session_key, {"type": "answer.delta", "session_id": event.session_key, "turn_id": event.turn_id, "delta": event.content_delta})
-        if event.thinking_delta:
-            await self._broadcast(event.session_key, {"type": "react.thinking.delta", "session_id": event.session_key, "turn_id": event.turn_id, "delta": event.thinking_delta})
-
-    async def _on_tool_started(self, event: ToolCallStarted) -> None:
-        await self._broadcast(event.session_key, {"type": "react.tool.started", "session_id": event.session_key, "turn_id": event.turn_id, "call_id": event.call_id, "tool_name": event.tool_name, "arguments": event.arguments})
-
-    async def _on_tool_completed(self, event: ToolCallCompleted) -> None:
-        await self._broadcast(event.session_key, {"type": "react.tool.completed", "session_id": event.session_key, "turn_id": event.turn_id, "call_id": event.call_id, "tool_name": event.tool_name, "status": event.status, "result_preview": event.result_preview})
+            await self._send_mapped(
+                websocket,
+                self._mapper.map_session_usage_snapshot(session_key, usage),
+            )
 
     async def _register(self, session_key: str, websocket: WebSocketApi) -> None:
         async with self._lock:
@@ -418,6 +315,12 @@ class WebChannel:
                     self._connections.pop(key, None)
             # 发送锁使用弱引用保存；连接对象仍存活时始终复用同一把锁，断开且无引用后
             # 自动回收，避免清理与并发发送之间出现双锁竞态。
+
+    async def _broadcast_mapped(self, mapped: MappedWebEvent) -> int:
+        sent = 0
+        for payload in mapped.payloads:
+            sent = await self._broadcast(mapped.session_key, payload)
+        return sent
 
     async def _broadcast(self, session_key: str, payload: dict[str, Any]) -> int:
         async with self._lock:
@@ -434,6 +337,14 @@ class WebChannel:
             await self._unregister(websocket)
         return sent
 
+    async def _send_mapped(
+        self,
+        websocket: WebSocketApi,
+        mapped: MappedWebEvent,
+    ) -> None:
+        for payload in mapped.payloads:
+            await self._send_json(websocket, payload)
+
     async def _send_json(
         self,
         websocket: WebSocketApi,
@@ -446,82 +357,27 @@ class WebChannel:
         async with send_lock:
             await websocket.send_json(payload)
 
-    async def _error(self, websocket: WebSocketApi, request_id: str, code: str, message: str) -> None:
-        await self._send_json(websocket, {"type": "error", "request_id": request_id, "code": code, "message": message})
+    async def _error(
+        self,
+        websocket: WebSocketApi,
+        request_id: str,
+        code: str,
+        message: str,
+    ) -> None:
+        await self._send_json(websocket, {
+            "type": "error",
+            "request_id": request_id,
+            "code": code,
+            "message": message,
+        })
 
     async def close(self) -> None:
         self._bus.unsubscribe_outbound(self.name, self._on_response)
-        self._events.off(TurnStarted, self._on_turn_started)
-        self._events.off(ContextCompactionStarted, self._on_context_compaction_started)
-        self._events.off(ContextCompactionCompleted, self._on_context_compaction_completed)
-        self._events.off(ContextCompactionFailed, self._on_context_compaction_failed)
-        self._events.off(ContextUsageUpdated, self._on_context_usage_updated)
-        self._events.off(SessionUsageUpdated, self._on_session_usage_updated)
-        self._events.off(SessionUpdated, self._on_session_updated)
-        self._events.off(TurnQueued, self._on_turn_queued)
-        self._events.off(TurnQueueRejected, self._on_turn_queue_rejected)
-        self._events.off(StreamDeltaReady, self._on_stream_delta)
-        self._events.off(ToolCallStarted, self._on_tool_started)
-        self._events.off(ToolCallCompleted, self._on_tool_completed)
+        for event_type in _WEB_EVENT_TYPES:
+            self._events.off(event_type, self._on_event)
         async with self._lock:
             self._connections.clear()
             self._socket_send_locks.clear()
-
-
-def _context_usage_frame(snapshot: dict[str, Any]) -> dict[str, Any]:
-    """把持久化快照转成兼容实时事件的 WebSocket 帧。"""
-
-    pressure = snapshot.get("pressure_tokens")
-    projected = snapshot.get("projected_tokens")
-    used = projected if projected is not None else pressure
-    breakdown = {
-        "system_prompt_tokens": int(snapshot.get("system_tokens") or 0),
-        "tools_tokens": int(snapshot.get("tools_tokens") or 0),
-        "conversation_tokens": int(snapshot.get("message_tokens") or 0),
-        "overhead_tokens": 0,
-    }
-    return {
-        "used_tokens": int(used or 0),
-        "context_window": int(snapshot.get("context_window") or 0),
-        "soft_limit_tokens": int(snapshot.get("soft_limit_tokens") or 0),
-        "hard_input_tokens": int(snapshot.get("hard_input_tokens") or 0),
-        "context_window_source": str(snapshot.get("context_window_source") or "unknown"),
-        "estimate_source": "provider_projected" if projected is not None else "unknown",
-        "breakdown": breakdown,
-        "sections": [],
-        **{key: snapshot[key] for key in (
-            "pressure_tokens", "projected_tokens", "surface_tokens", "system_tokens",
-            "tools_tokens", "message_tokens", "as_of_seq", "model_runtime_id", "model",
-        ) if snapshot.get(key) is not None},
-    }
-
-
-def _session_usage_frame(snapshot: dict[str, Any]) -> dict[str, Any]:
-    """把累计字段限制在前端协议的明确命名和非负范围内。"""
-
-    values = {
-        "total_uncached_input_tokens": max(0, int(snapshot.get("total_uncached_input_tokens") or 0)),
-        "total_cache_read_tokens": max(0, int(snapshot.get("total_cache_read_tokens") or 0)),
-        "total_cache_write_tokens": max(0, int(snapshot.get("total_cache_write_tokens") or 0)),
-        "total_input_tokens": max(0, int(snapshot.get("total_input_tokens") or 0)),
-        "total_output_tokens": max(0, int(snapshot.get("total_output_tokens") or 0)),
-    }
-    values["cache_hit_rate"] = (
-        float(snapshot["cache_hit_rate"])
-        if snapshot.get("cache_hit_rate") is not None else None
-    )
-    return values
-
-
-def normalize_web_session_id(value: object) -> str | None:
-    text = str(value or "").strip()
-    if not text:
-        return None
-    if text.startswith("web:") and text[4:]:
-        return text
-    if ":" not in text:
-        return f"web:{text}"
-    return None
 
 
 __all__ = ["WebChannel", "normalize_web_session_id"]

--- a/agent/web_commands.py
+++ b/agent/web_commands.py
@@ -1,0 +1,152 @@
+"""与具体 Web 传输无关的命令校验和执行服务。"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+from uuid import uuid4
+
+from agent.agent_loop import InterruptResult
+from agent.message_bus import InboundMessage, MessageBus
+
+MAX_MESSAGE_LENGTH = 32 * 1024
+MAX_MEDIA_COUNT = 8
+
+
+class InterruptController(Protocol):
+    async def request_interrupt(self, session_key: str) -> InterruptResult: ...
+
+
+class WebCommandError(Exception):
+    """可由任意 Web 传输稳定转换为协议错误的命令异常。"""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedWebMessage:
+    """已完成校验和会话准备、但尚未发布的入站消息。"""
+
+    session_key: str
+    request_id: str
+    created_session: bool
+    message: InboundMessage
+
+
+class WebCommandService:
+    """执行可被 WebSocket、HTTP 等传输复用的 Web 命令。"""
+
+    def __init__(
+        self,
+        bus: MessageBus,
+        interrupt_controller: InterruptController,
+        *,
+        media_root: Path | None = None,
+        ensure_session: Callable[[str], Awaitable[object]] | None = None,
+    ) -> None:
+        self._bus = bus
+        self._interrupt = interrupt_controller
+        self._media_root = media_root.resolve() if media_root is not None else None
+        self._ensure_session = ensure_session
+
+    async def create_session(self) -> str:
+        """先持久化空会话，使创建响应后的查询不会短暂返回 404。"""
+
+        session_key = f"web:{uuid4().hex}"
+        if self._ensure_session is not None:
+            await self._ensure_session(session_key)
+        return session_key
+
+    async def prepare_message(
+        self,
+        *,
+        request_id: str,
+        session_id: object,
+        text: object,
+        media: object,
+    ) -> PreparedWebMessage:
+        content = str(text or "")
+        attachments = _normalize_media(media)
+        if not content.strip() and not attachments:
+            raise WebCommandError("empty_message", "消息不能为空")
+        if len(content) > MAX_MESSAGE_LENGTH or len(attachments) > MAX_MEDIA_COUNT:
+            raise WebCommandError("message_too_large", "消息或媒体数量超过限制")
+        if not self._media_is_allowed(attachments):
+            raise WebCommandError("invalid_media", "附件路径无效或不属于当前 workspace")
+
+        session_key = normalize_web_session_id(session_id)
+        created_session = session_key is None
+        if session_key is None:
+            # 校验全部完成后才创建，避免非法首轮请求留下空会话。
+            session_key = await self.create_session()
+        chat_id = session_key.split(":", 1)[1]
+        message = InboundMessage(
+            "web",
+            "web",
+            chat_id,
+            content,
+            attachments,
+            {"request_id": request_id},
+        )
+        return PreparedWebMessage(session_key, request_id, created_session, message)
+
+    async def submit_message(self, prepared: PreparedWebMessage) -> None:
+        await self._bus.publish_inbound(prepared.message)
+
+    async def stop_turn(self, session_key: str) -> InterruptResult:
+        return await self._interrupt.request_interrupt(session_key)
+
+    def get_active_turn_snapshot(self, session_key: str) -> dict[str, Any] | None:
+        snapshotter = getattr(self._interrupt, "get_active_turn_snapshot", None)
+        if not callable(snapshotter):
+            return None
+        snapshot = snapshotter(session_key)
+        return dict(snapshot) if snapshot else None
+
+    def _media_is_allowed(self, media: list[str]) -> bool:
+        if not media or self._media_root is None:
+            return True
+        for value in media:
+            try:
+                path = Path(value).expanduser().resolve()
+                path.relative_to(self._media_root)
+            except (OSError, ValueError):
+                return False
+            if not path.is_file():
+                return False
+        return True
+
+
+def _normalize_media(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [
+        item.strip()
+        for item in value
+        if isinstance(item, str) and item.strip()
+    ]
+
+
+def normalize_web_session_id(value: object) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.startswith("web:") and text[4:]:
+        return text
+    if ":" not in text:
+        return f"web:{text}"
+    return None
+
+
+__all__ = [
+    "InterruptController",
+    "PreparedWebMessage",
+    "WebCommandError",
+    "WebCommandService",
+    "normalize_web_session_id",
+]

--- a/agent/web_events.py
+++ b/agent/web_events.py
@@ -1,0 +1,339 @@
+"""Agent 消息和生命周期事件到 Web 协议帧的纯映射。"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+from agent.agent_loop import InterruptResult
+from agent.event_bus import (
+    ContextCompactionCompleted,
+    ContextCompactionFailed,
+    ContextCompactionStarted,
+    ContextUsageUpdated,
+    SessionUsageUpdated,
+    SessionUpdated,
+    StreamDeltaReady,
+    ToolCallCompleted,
+    ToolCallStarted,
+    TurnQueued,
+    TurnQueueRejected,
+    TurnStarted,
+)
+from agent.message_bus import OutboundMessage
+
+JsonPayload: TypeAlias = dict[str, Any]
+WebLifecycleEvent: TypeAlias = (
+    TurnStarted
+    | ContextCompactionStarted
+    | ContextCompactionCompleted
+    | ContextCompactionFailed
+    | ContextUsageUpdated
+    | SessionUsageUpdated
+    | SessionUpdated
+    | TurnQueued
+    | TurnQueueRejected
+    | StreamDeltaReady
+    | ToolCallStarted
+    | ToolCallCompleted
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MappedWebEvent:
+    session_key: str
+    payloads: tuple[JsonPayload, ...]
+
+
+class WebEventMapper:
+    """不持有连接状态的 Web 协议映射器。"""
+
+    def map_outbound(self, message: OutboundMessage) -> MappedWebEvent:
+        session_key = f"{message.channel}:{message.chat_id}"
+        metadata = dict(message.metadata)
+        return _mapped(session_key, {
+            "type": "message.final",
+            "request_id": str(metadata.get("request_id") or ""),
+            "session_id": session_key,
+            "turn_id": str(metadata.get("turn_id") or ""),
+            "content": message.content,
+            "thinking": message.thinking,
+            "media": list(message.media),
+            "message_id": str(metadata.get("message_id") or ""),
+            "metadata": metadata,
+        })
+
+    def map_event(self, event: WebLifecycleEvent) -> MappedWebEvent:
+        if isinstance(event, TurnStarted):
+            return _mapped(event.session_key, {
+                "type": "turn.started",
+                "request_id": event.request_id,
+                "session_id": event.session_key,
+                "turn_id": event.turn_id,
+            })
+        if isinstance(event, ContextCompactionStarted):
+            return _mapped(event.session_key, {
+                "type": "context.compaction.started",
+                "session_id": event.session_key,
+                "turn_id": event.turn_id,
+                "trigger": event.trigger,
+                "estimated_tokens": event.estimated_tokens,
+            })
+        if isinstance(event, ContextCompactionCompleted):
+            return _mapped(event.session_key, {
+                "type": "context.compaction.completed",
+                "session_id": event.session_key,
+                "turn_id": event.turn_id,
+                "trigger": event.trigger,
+                "estimated_tokens": event.estimated_tokens,
+                "compacted": event.compacted,
+            })
+        if isinstance(event, ContextCompactionFailed):
+            return _mapped(event.session_key, {
+                "type": "context.compaction.failed",
+                "session_id": event.session_key,
+                "turn_id": event.turn_id,
+                "trigger": event.trigger,
+                "estimated_tokens": event.estimated_tokens,
+                "message": event.error,
+            })
+        if isinstance(event, ContextUsageUpdated):
+            payload = {
+                "type": "context.usage.updated",
+                "session_id": event.session_key,
+                "turn_id": event.turn_id,
+                "used_tokens": event.used_tokens,
+                "context_window": event.context_window,
+                "soft_limit_tokens": event.soft_limit_tokens,
+                "hard_input_tokens": event.hard_input_tokens,
+                "context_window_source": event.context_window_source,
+                "estimate_source": event.estimate_source,
+                "breakdown": dict(event.breakdown),
+                "sections": [dict(section) for section in event.sections],
+            }
+            optional = {
+                "pressure_tokens": event.pressure_tokens,
+                "projected_tokens": event.projected_tokens,
+                "surface_tokens": event.surface_tokens,
+                "system_tokens": event.system_tokens,
+                "tools_tokens": event.tools_tokens,
+                "message_tokens": event.message_tokens,
+                "as_of_seq": event.as_of_seq,
+                "model_runtime_id": event.model_runtime_id,
+                "model": event.model,
+            }
+            payload.update({key: value for key, value in optional.items() if value is not None})
+            return _mapped(event.session_key, payload)
+        if isinstance(event, SessionUsageUpdated):
+            return _mapped(event.session_key, {
+                "type": "session.usage.updated",
+                "session_id": event.session_key,
+                "turn_id": event.turn_id,
+                "total_uncached_input_tokens": event.total_uncached_input_tokens,
+                "total_cache_read_tokens": event.total_cache_read_tokens,
+                "total_cache_write_tokens": event.total_cache_write_tokens,
+                "total_input_tokens": event.total_input_tokens,
+                "cache_hit_rate": event.cache_hit_rate,
+                "total_output_tokens": event.total_output_tokens,
+            })
+        if isinstance(event, SessionUpdated):
+            return _mapped(event.session_key, {
+                "type": "session.updated",
+                "session": dict(event.session),
+            })
+        if isinstance(event, TurnQueued):
+            return _mapped(event.session_key, {
+                "type": "turn.queued",
+                "request_id": event.request_id,
+                "session_id": event.session_key,
+                "position": event.position,
+            })
+        if isinstance(event, TurnQueueRejected):
+            messages = {
+                "queue_full": "当前任务较多，请稍后再试",
+                "session_busy": "当前会话正在处理消息",
+                "closed": "服务正在关闭，请稍后再试",
+            }
+            return _mapped(event.session_key, {
+                "type": "error",
+                "request_id": event.request_id,
+                "session_id": event.session_key,
+                "code": event.reason,
+                "message": messages.get(event.reason, "消息暂时无法处理"),
+            })
+        if isinstance(event, StreamDeltaReady):
+            payloads: list[JsonPayload] = []
+            # 同一事件含双 delta 时正文必须先到，保持前端 reducer 的既有时序。
+            if event.content_delta:
+                payloads.append({
+                    "type": "answer.delta",
+                    "session_id": event.session_key,
+                    "turn_id": event.turn_id,
+                    "delta": event.content_delta,
+                })
+            if event.thinking_delta:
+                payloads.append({
+                    "type": "react.thinking.delta",
+                    "session_id": event.session_key,
+                    "turn_id": event.turn_id,
+                    "delta": event.thinking_delta,
+                })
+            return MappedWebEvent(event.session_key, tuple(payloads))
+        if isinstance(event, ToolCallStarted):
+            return _mapped(event.session_key, {
+                "type": "react.tool.started",
+                "session_id": event.session_key,
+                "turn_id": event.turn_id,
+                "call_id": event.call_id,
+                "tool_name": event.tool_name,
+                "arguments": dict(event.arguments),
+            })
+        if isinstance(event, ToolCallCompleted):
+            return _mapped(event.session_key, {
+                "type": "react.tool.completed",
+                "session_id": event.session_key,
+                "turn_id": event.turn_id,
+                "call_id": event.call_id,
+                "tool_name": event.tool_name,
+                "status": event.status,
+                "result_preview": event.result_preview,
+            })
+        raise TypeError(f"不支持的 Web 事件: {type(event).__name__}")
+
+    def map_context_usage_snapshot(
+        self,
+        session_key: str,
+        snapshot: Mapping[str, Any],
+    ) -> MappedWebEvent:
+        pressure = snapshot.get("pressure_tokens")
+        projected = snapshot.get("projected_tokens")
+        used = projected if projected is not None else pressure
+        payload = {
+            "type": "context.usage.updated",
+            "session_id": session_key,
+            "turn_id": "",
+            "used_tokens": int(used or 0),
+            "context_window": int(snapshot.get("context_window") or 0),
+            "soft_limit_tokens": int(snapshot.get("soft_limit_tokens") or 0),
+            "hard_input_tokens": int(snapshot.get("hard_input_tokens") or 0),
+            "context_window_source": str(snapshot.get("context_window_source") or "unknown"),
+            "estimate_source": "provider_projected" if projected is not None else "unknown",
+            "breakdown": {
+                "system_prompt_tokens": int(snapshot.get("system_tokens") or 0),
+                "tools_tokens": int(snapshot.get("tools_tokens") or 0),
+                "conversation_tokens": int(snapshot.get("message_tokens") or 0),
+                "overhead_tokens": 0,
+            },
+            "sections": [],
+        }
+        for key in (
+            "pressure_tokens",
+            "projected_tokens",
+            "surface_tokens",
+            "system_tokens",
+            "tools_tokens",
+            "message_tokens",
+            "as_of_seq",
+            "model_runtime_id",
+            "model",
+        ):
+            if snapshot.get(key) is not None:
+                payload[key] = snapshot[key]
+        return _mapped(session_key, payload)
+
+    def map_context_usage_reset(self, session_key: str) -> MappedWebEvent:
+        return _mapped(session_key, {
+            "type": "context.usage.reset",
+            "session_id": session_key,
+        })
+
+    def map_session_usage_snapshot(
+        self,
+        session_key: str,
+        snapshot: Mapping[str, Any],
+    ) -> MappedWebEvent:
+        payload = {
+            "type": "session.usage.updated",
+            "session_id": session_key,
+            "turn_id": "",
+            "total_uncached_input_tokens": _non_negative_int(
+                snapshot.get("total_uncached_input_tokens")
+            ),
+            "total_cache_read_tokens": _non_negative_int(
+                snapshot.get("total_cache_read_tokens")
+            ),
+            "total_cache_write_tokens": _non_negative_int(
+                snapshot.get("total_cache_write_tokens")
+            ),
+            "total_input_tokens": _non_negative_int(snapshot.get("total_input_tokens")),
+            "cache_hit_rate": (
+                float(snapshot["cache_hit_rate"])
+                if snapshot.get("cache_hit_rate") is not None
+                else None
+            ),
+            "total_output_tokens": _non_negative_int(snapshot.get("total_output_tokens")),
+        }
+        return _mapped(session_key, payload)
+
+    def map_active_turn_snapshot(
+        self,
+        session_key: str,
+        snapshot: Mapping[str, Any],
+    ) -> MappedWebEvent:
+        return _mapped(session_key, {"type": "turn.snapshot", **dict(snapshot)})
+
+    def map_interrupted(
+        self,
+        session_key: str,
+        request_id: str,
+        result: InterruptResult,
+    ) -> MappedWebEvent:
+        payload = {
+            "type": "turn.interrupted",
+            "request_id": request_id,
+            "session_id": session_key,
+            "turn_id": result.turn_id,
+            "status": result.status,
+        }
+        if result.duration_ms is not None:
+            payload["duration_ms"] = result.duration_ms
+        if result.ended_at:
+            payload["ended_at"] = result.ended_at
+        return _mapped(session_key, payload)
+
+    def map_pending_notification(
+        self,
+        session_key: str,
+        *,
+        content: str,
+        message_id: str,
+        metadata: Mapping[str, Any],
+    ) -> MappedWebEvent:
+        return _mapped(session_key, {
+            "type": "message.final",
+            "request_id": "",
+            "session_id": session_key,
+            "turn_id": "",
+            "content": content,
+            "thinking": "",
+            "media": [],
+            "message_id": message_id,
+            "metadata": dict(metadata),
+        })
+
+
+def _mapped(session_key: str, payload: JsonPayload) -> MappedWebEvent:
+    return MappedWebEvent(session_key, (payload,))
+
+
+def _non_negative_int(value: object) -> int:
+    return max(0, int(value or 0))
+
+
+__all__ = [
+    "JsonPayload",
+    "MappedWebEvent",
+    "WebEventMapper",
+    "WebLifecycleEvent",
+]

--- a/tests/unit/agent/test_web_commands.py
+++ b/tests/unit/agent/test_web_commands.py
@@ -1,0 +1,180 @@
+"""Web 命令服务的传输无关契约测试。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.agent_loop import InterruptResult
+from agent.message_bus import MessageBus
+from agent.web_commands import (
+    WebCommandError,
+    WebCommandService,
+    normalize_web_session_id,
+)
+
+
+class Interrupt:
+    def __init__(self) -> None:
+        self.requested: list[str] = []
+
+    async def request_interrupt(self, session_key: str) -> InterruptResult:
+        self.requested.append(session_key)
+        return InterruptResult("interrupted", session_key, "turn-1", 12, "ended")
+
+    def get_active_turn_snapshot(self, session_key: str) -> dict[str, str] | None:
+        if session_key != "web:chat":
+            return None
+        return {"session_id": session_key, "turn_id": "turn-1"}
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("chat", "web:chat"),
+        (" web:chat ", "web:chat"),
+        ("other:chat", None),
+        ("web:", None),
+    ],
+)
+def test_normalize_web_session_id(value: object, expected: str | None) -> None:
+    assert normalize_web_session_id(value) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("text", "media", "code"),
+    [
+        ("   ", [], "empty_message"),
+        ("x" * (32 * 1024 + 1), [], "message_too_large"),
+        ("x", [str(index) for index in range(9)], "message_too_large"),
+    ],
+    ids=["empty", "text-too-large", "media-too-large"],
+)
+async def test_validation_failure_does_not_create_or_publish(
+    text: str,
+    media: list[str],
+    code: str,
+) -> None:
+    bus = MessageBus()
+    created: list[str] = []
+
+    async def ensure_session(session_key: str) -> object:
+        created.append(session_key)
+        return object()
+
+    service = WebCommandService(bus, Interrupt(), ensure_session=ensure_session)
+
+    with pytest.raises(WebCommandError) as raised:
+        await service.prepare_message(
+            request_id="request-1",
+            session_id=None,
+            text=text,
+            media=media,
+        )
+
+    assert raised.value.code == code
+    assert created == []
+    assert bus._inbound.empty()
+
+
+@pytest.mark.asyncio
+async def test_invalid_media_does_not_create_or_publish(tmp_path: Path) -> None:
+    media_root = tmp_path / "uploads"
+    media_root.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    bus = MessageBus()
+    created: list[str] = []
+
+    async def ensure_session(session_key: str) -> object:
+        created.append(session_key)
+        return object()
+
+    service = WebCommandService(
+        bus,
+        Interrupt(),
+        media_root=media_root,
+        ensure_session=ensure_session,
+    )
+
+    with pytest.raises(WebCommandError) as raised:
+        await service.prepare_message(
+            request_id="request-media",
+            session_id=None,
+            text="read",
+            media=[str(outside)],
+        )
+
+    assert raised.value.code == "invalid_media"
+    assert created == []
+    assert bus._inbound.empty()
+
+
+@pytest.mark.asyncio
+async def test_prepare_and_submit_are_separate_and_preserve_message() -> None:
+    bus = MessageBus()
+    created: list[str] = []
+
+    async def ensure_session(session_key: str) -> object:
+        created.append(session_key)
+        return object()
+
+    service = WebCommandService(bus, Interrupt(), ensure_session=ensure_session)
+
+    prepared = await service.prepare_message(
+        request_id="request-new",
+        session_id=None,
+        text="hello",
+        media=[" image.png ", "", 1],
+    )
+
+    assert prepared.created_session is True
+    assert prepared.session_key.startswith("web:")
+    assert created == [prepared.session_key]
+    assert bus._inbound.empty()
+    assert prepared.message.session_key == prepared.session_key
+    assert prepared.message.content == "hello"
+    assert prepared.message.media == ["image.png"]
+    assert prepared.message.metadata == {"request_id": "request-new"}
+
+    await service.submit_message(prepared)
+
+    assert await bus.consume_inbound() is prepared.message
+
+
+@pytest.mark.asyncio
+async def test_existing_session_does_not_create_another_session() -> None:
+    bus = MessageBus()
+
+    async def ensure_session(_session_key: str) -> object:
+        raise AssertionError("existing session must not be recreated")
+
+    service = WebCommandService(bus, Interrupt(), ensure_session=ensure_session)
+    prepared = await service.prepare_message(
+        request_id="request-existing",
+        session_id="chat",
+        text="hello",
+        media=None,
+    )
+
+    assert prepared.created_session is False
+    assert prepared.session_key == "web:chat"
+
+
+@pytest.mark.asyncio
+async def test_interrupt_and_snapshot_are_delegated_without_transport_types() -> None:
+    interrupt = Interrupt()
+    service = WebCommandService(MessageBus(), interrupt)
+
+    result = await service.stop_turn("web:chat")
+
+    assert result == InterruptResult("interrupted", "web:chat", "turn-1", 12, "ended")
+    assert interrupt.requested == ["web:chat"]
+    assert service.get_active_turn_snapshot("web:chat") == {
+        "session_id": "web:chat",
+        "turn_id": "turn-1",
+    }

--- a/tests/unit/agent/test_web_events.py
+++ b/tests/unit/agent/test_web_events.py
@@ -1,0 +1,320 @@
+"""Web 事件映射器的协议契约测试。"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.agent_loop import InterruptResult
+from agent.event_bus import (
+    ContextCompactionCompleted,
+    ContextCompactionFailed,
+    ContextCompactionStarted,
+    ContextUsageUpdated,
+    SessionUsageUpdated,
+    SessionUpdated,
+    StreamDeltaReady,
+    ToolCallCompleted,
+    ToolCallStarted,
+    TurnQueued,
+    TurnQueueRejected,
+    TurnStarted,
+)
+from agent.message_bus import OutboundMessage
+from agent.web_events import WebEventMapper
+
+
+def test_outbound_message_maps_complete_final_payload() -> None:
+    message = OutboundMessage(
+        "web",
+        "chat",
+        "answer",
+        thinking="reason",
+        media=["result.png"],
+        metadata={
+            "request_id": "request-1",
+            "turn_id": "turn-1",
+            "message_id": "message-1",
+            "notification_id": "notification-1",
+        },
+    )
+
+    mapped = WebEventMapper().map_outbound(message)
+
+    assert mapped.session_key == "web:chat"
+    assert mapped.payloads == ({
+        "type": "message.final",
+        "request_id": "request-1",
+        "session_id": "web:chat",
+        "turn_id": "turn-1",
+        "content": "answer",
+        "thinking": "reason",
+        "media": ["result.png"],
+        "message_id": "message-1",
+        "metadata": message.metadata,
+    },)
+    assert mapped.payloads[0]["metadata"] is not message.metadata
+
+
+@pytest.mark.parametrize(
+    ("event", "expected"),
+    [
+        (
+            TurnStarted("web:chat", "turn-1", "request-1", "ignored content"),
+            {
+                "type": "turn.started",
+                "request_id": "request-1",
+                "session_id": "web:chat",
+                "turn_id": "turn-1",
+            },
+        ),
+        (
+            ContextCompactionStarted("web:chat", "turn-1", "soft_limit", 1200),
+            {
+                "type": "context.compaction.started",
+                "session_id": "web:chat",
+                "turn_id": "turn-1",
+                "trigger": "soft_limit",
+                "estimated_tokens": 1200,
+            },
+        ),
+        (
+            ContextCompactionCompleted("web:chat", "turn-1", "soft_limit", 1200, True),
+            {
+                "type": "context.compaction.completed",
+                "session_id": "web:chat",
+                "turn_id": "turn-1",
+                "trigger": "soft_limit",
+                "estimated_tokens": 1200,
+                "compacted": True,
+            },
+        ),
+        (
+            ContextCompactionFailed("web:chat", "turn-1", "soft_limit", 1200, "failed"),
+            {
+                "type": "context.compaction.failed",
+                "session_id": "web:chat",
+                "turn_id": "turn-1",
+                "trigger": "soft_limit",
+                "estimated_tokens": 1200,
+                "message": "failed",
+            },
+        ),
+        (
+            SessionUsageUpdated("web:chat", "turn-1", 1, 2, 3, 6, 0.5, 4),
+            {
+                "type": "session.usage.updated",
+                "session_id": "web:chat",
+                "turn_id": "turn-1",
+                "total_uncached_input_tokens": 1,
+                "total_cache_read_tokens": 2,
+                "total_cache_write_tokens": 3,
+                "total_input_tokens": 6,
+                "cache_hit_rate": 0.5,
+                "total_output_tokens": 4,
+            },
+        ),
+        (
+            SessionUpdated("web:chat", {"key": "web:chat", "title": "title"}),
+            {
+                "type": "session.updated",
+                "session": {"key": "web:chat", "title": "title"},
+            },
+        ),
+        (
+            TurnQueued("web:chat", "request-1", 2),
+            {
+                "type": "turn.queued",
+                "request_id": "request-1",
+                "session_id": "web:chat",
+                "position": 2,
+            },
+        ),
+        (
+            ToolCallStarted("web:chat", "turn-1", "call-1", "read_file", {"path": "a"}),
+            {
+                "type": "react.tool.started",
+                "session_id": "web:chat",
+                "turn_id": "turn-1",
+                "call_id": "call-1",
+                "tool_name": "read_file",
+                "arguments": {"path": "a"},
+            },
+        ),
+        (
+            ToolCallCompleted("web:chat", "turn-1", "call-1", "read_file", "ok", "done"),
+            {
+                "type": "react.tool.completed",
+                "session_id": "web:chat",
+                "turn_id": "turn-1",
+                "call_id": "call-1",
+                "tool_name": "read_file",
+                "status": "ok",
+                "result_preview": "done",
+            },
+        ),
+    ],
+    ids=[
+        "turn-started",
+        "compaction-started",
+        "compaction-completed",
+        "compaction-failed",
+        "session-usage",
+        "session-updated",
+        "turn-queued",
+        "tool-started",
+        "tool-completed",
+    ],
+)
+def test_lifecycle_event_payloads_are_preserved(event: object, expected: dict) -> None:
+    mapped = WebEventMapper().map_event(event)  # type: ignore[arg-type]
+
+    assert mapped.session_key == "web:chat"
+    assert mapped.payloads == (expected,)
+
+
+@pytest.mark.parametrize(
+    ("reason", "message"),
+    [
+        ("queue_full", "当前任务较多，请稍后再试"),
+        ("session_busy", "当前会话正在处理消息"),
+        ("closed", "服务正在关闭，请稍后再试"),
+        ("unknown", "消息暂时无法处理"),
+    ],
+)
+def test_queue_rejection_keeps_stable_chinese_message(reason: str, message: str) -> None:
+    mapped = WebEventMapper().map_event(
+        TurnQueueRejected("web:chat", "request-1", reason)
+    )
+
+    assert mapped.payloads == ({
+        "type": "error",
+        "request_id": "request-1",
+        "session_id": "web:chat",
+        "code": reason,
+        "message": message,
+    },)
+
+
+def test_stream_content_precedes_thinking_delta() -> None:
+    mapped = WebEventMapper().map_event(
+        StreamDeltaReady("web:chat", "turn-1", "answer", "reason")
+    )
+
+    assert [payload["type"] for payload in mapped.payloads] == [
+        "answer.delta",
+        "react.thinking.delta",
+    ]
+    assert [payload["delta"] for payload in mapped.payloads] == ["answer", "reason"]
+
+
+def test_context_usage_event_only_includes_present_optional_fields() -> None:
+    mapped = WebEventMapper().map_event(ContextUsageUpdated(
+        session_key="web:chat",
+        turn_id="turn-1",
+        used_tokens=50,
+        context_window=100,
+        soft_limit_tokens=80,
+        hard_input_tokens=95,
+        context_window_source="catalog",
+        estimate_source="provider",
+        breakdown={"conversation_tokens": 50},
+        sections=({"name": "conversation"},),
+        pressure_tokens=50,
+        model="model",
+    ))
+
+    payload = mapped.payloads[0]
+    assert payload["pressure_tokens"] == 50
+    assert payload["model"] == "model"
+    assert "projected_tokens" not in payload
+    assert "as_of_seq" not in payload
+    assert payload["sections"] == [{"name": "conversation"}]
+
+
+def test_context_usage_snapshot_preserves_projection_rules() -> None:
+    mapped = WebEventMapper().map_context_usage_snapshot("web:chat", {
+        "pressure_tokens": 100,
+        "projected_tokens": 120,
+        "context_window": 1000,
+        "soft_limit_tokens": 800,
+        "hard_input_tokens": 950,
+        "context_window_source": "catalog",
+        "system_tokens": 10,
+        "tools_tokens": 20,
+        "message_tokens": 70,
+        "model": "model",
+    })
+
+    payload = mapped.payloads[0]
+    assert payload["used_tokens"] == 120
+    assert payload["estimate_source"] == "provider_projected"
+    assert payload["breakdown"] == {
+        "system_prompt_tokens": 10,
+        "tools_tokens": 20,
+        "conversation_tokens": 70,
+        "overhead_tokens": 0,
+    }
+    assert payload["pressure_tokens"] == 100
+    assert payload["projected_tokens"] == 120
+    assert "surface_tokens" not in payload
+
+
+def test_snapshot_and_direct_response_helpers_keep_protocol_shapes() -> None:
+    mapper = WebEventMapper()
+
+    reset = mapper.map_context_usage_reset("web:chat")
+    usage = mapper.map_session_usage_snapshot("web:chat", {
+        "total_uncached_input_tokens": -1,
+        "total_cache_read_tokens": 2,
+        "total_cache_write_tokens": 3,
+        "total_input_tokens": 4,
+        "cache_hit_rate": None,
+        "total_output_tokens": 5,
+    })
+    snapshot = mapper.map_active_turn_snapshot(
+        "web:chat", {"session_id": "web:chat", "turn_id": "turn-1"}
+    )
+    interrupted = mapper.map_interrupted(
+        "web:chat",
+        "request-1",
+        InterruptResult("interrupted", "web:chat", "turn-1", 10, "ended"),
+    )
+
+    assert reset.payloads == ({"type": "context.usage.reset", "session_id": "web:chat"},)
+    assert usage.payloads[0]["total_uncached_input_tokens"] == 0
+    assert usage.payloads[0]["cache_hit_rate"] is None
+    assert snapshot.payloads == ({
+        "type": "turn.snapshot",
+        "session_id": "web:chat",
+        "turn_id": "turn-1",
+    },)
+    assert interrupted.payloads == ({
+        "type": "turn.interrupted",
+        "request_id": "request-1",
+        "session_id": "web:chat",
+        "turn_id": "turn-1",
+        "status": "interrupted",
+        "duration_ms": 10,
+        "ended_at": "ended",
+    },)
+
+
+def test_pending_notification_maps_as_final_message() -> None:
+    mapped = WebEventMapper().map_pending_notification(
+        "web:chat",
+        content="reminder",
+        message_id="notification-1",
+        metadata={"notification_id": "notification-1"},
+    )
+
+    assert mapped.payloads == ({
+        "type": "message.final",
+        "request_id": "",
+        "session_id": "web:chat",
+        "turn_id": "",
+        "content": "reminder",
+        "thinking": "",
+        "media": [],
+        "message_id": "notification-1",
+        "metadata": {"notification_id": "notification-1"},
+    },)


### PR DESCRIPTION
提取传输无关的 Web 命令服务和纯事件映射器。
保持现有 WebSocket 帧协议、订阅恢复与通知送达语义不变。