### PR TITLE
Feature/sandbox workspace policy

### DIFF
--- a/agent/channel.py
+++ b/agent/channel.py
@@ -142,6 +142,7 @@ class WebChannel:
                 "request_id": request_id,
                 "session_id": session_key,
             })
+            await self._send_sandbox_snapshot(session_key, websocket)
             return
 
         session_key = normalize_web_session_id(frame.get("session_id"))
@@ -183,6 +184,7 @@ class WebChannel:
                     "request_id": request_id,
                     "session_id": prepared.session_key,
                 })
+                await self._send_sandbox_snapshot(prepared.session_key, websocket)
             await self._commands.submit_message(prepared)
             return
         if frame_type == "turn.stop" and session_key is not None:

--- a/agent/channel.py
+++ b/agent/channel.py
@@ -15,6 +15,7 @@ from agent.event_bus import (
     ContextCompactionStarted,
     ContextUsageUpdated,
     EventBus,
+    SandboxApprovalRequested,
     SessionUsageUpdated,
     SessionUpdated,
     StreamDeltaReady,
@@ -57,6 +58,7 @@ _WEB_EVENT_TYPES = (
     StreamDeltaReady,
     ToolCallStarted,
     ToolCallCompleted,
+    SandboxApprovalRequested,
 )
 
 
@@ -71,10 +73,14 @@ class WebChannel:
         *,
         media_root: Path | None = None,
         proactive_store: ProactiveStore | None = None,
-        ensure_session: Callable[[str], Awaitable[object]] | None = None,
+        ensure_session: Callable[..., Awaitable[object]] | None = None,
         context_usage_loader: Callable[[str], Awaitable[dict[str, Any] | None]] | None = None,
         session_usage_loader: Callable[[str], Awaitable[dict[str, Any] | None]] | None = None,
         context_runtime_id: str = "",
+        sandbox_loader: Callable[[str], Awaitable[dict[str, Any] | None]] | None = None,
+        sandbox_mode_writer: Callable[[str, str], Awaitable[dict[str, Any]]] | None = None,
+        workspace_writer: Callable[[str, str | None], Awaitable[dict[str, Any]]] | None = None,
+        approvals: Any | None = None,
     ) -> None:
         self._bus = bus
         self._events = event_bus
@@ -83,6 +89,10 @@ class WebChannel:
             interrupt_controller,
             media_root=media_root,
             ensure_session=ensure_session,
+            sandbox_loader=sandbox_loader,
+            sandbox_mode_writer=sandbox_mode_writer,
+            workspace_writer=workspace_writer,
+            approvals=approvals,
         )
         self._mapper = WebEventMapper()
         self._proactive_store = proactive_store
@@ -117,7 +127,15 @@ class WebChannel:
             await self._send_json(websocket, {"type": "pong", "request_id": request_id})
             return
         if frame_type == "session.create":
-            session_key = await self._commands.create_session()
+            try:
+                session_key = await self._commands.create_session(
+                    workspace_id=str(frame.get("workspace_id") or "") or None,
+                    sandbox_mode=str(frame.get("sandbox_mode") or "read-only"),
+                    risk_confirmed=frame.get("risk_confirmed") is True,
+                )
+            except WebCommandError as error:
+                await self._error(websocket, request_id, error.code, error.message)
+                return
             await self._register(session_key, websocket)
             await self._send_json(websocket, {
                 "type": "session.created",
@@ -136,6 +154,8 @@ class WebChannel:
             })
             await self._send_context_usage_snapshot(session_key, websocket)
             await self._send_session_usage_snapshot(session_key, websocket)
+            await self._send_sandbox_snapshot(session_key, websocket)
+            await self._send_pending_approvals(session_key, websocket)
             # 订阅确认后只给当前连接补发运行中快照，用于刷新/重连恢复流式草稿。
             await self._send_active_turn_snapshot(session_key, websocket)
             await self._replay_pending_notifications(session_key, websocket)
@@ -147,6 +167,9 @@ class WebChannel:
                     session_id=frame.get("session_id"),
                     text=frame.get("text"),
                     media=frame.get("media", []),
+                    workspace_id=str(frame.get("workspace_id") or "") or None,
+                    sandbox_mode=str(frame.get("sandbox_mode") or "read-only"),
+                    risk_confirmed=frame.get("risk_confirmed") is True,
                 )
             except WebCommandError as error:
                 await self._error(websocket, request_id, error.code, error.message)
@@ -168,6 +191,53 @@ class WebChannel:
                 websocket,
                 self._mapper.map_interrupted(session_key, request_id, result),
             )
+            return
+        if frame_type == "sandbox.mode.set" and session_key is not None:
+            try:
+                snapshot = await self._commands.set_sandbox_mode(
+                    session_key,
+                    str(frame.get("sandbox_mode") or ""),
+                    risk_confirmed=frame.get("risk_confirmed") is True,
+                )
+            except WebCommandError as error:
+                await self._error(websocket, request_id, error.code, error.message)
+                return
+            await self._broadcast(session_key, {
+                "type": "sandbox.updated",
+                "request_id": request_id,
+                "sandbox": snapshot,
+            })
+            return
+        if frame_type == "workspace.bind" and session_key is not None:
+            try:
+                snapshot = await self._commands.bind_workspace(
+                    session_key,
+                    str(frame.get("workspace_id") or "").strip() or None,
+                )
+            except WebCommandError as error:
+                await self._error(websocket, request_id, error.code, error.message)
+                return
+            await self._broadcast(session_key, {
+                "type": "sandbox.updated",
+                "request_id": request_id,
+                "sandbox": snapshot,
+            })
+            return
+        if frame_type == "approval.decide" and session_key is not None:
+            approval_id = str(frame.get("approval_id") or "")
+            decision = str(frame.get("decision") or "")
+            try:
+                await self._commands.decide_approval(approval_id, session_key, decision)
+            except WebCommandError as error:
+                await self._error(websocket, request_id, error.code, error.message)
+                return
+            await self._broadcast(session_key, {
+                "type": "approval.resolved",
+                "request_id": request_id,
+                "session_id": session_key,
+                "approval_id": approval_id,
+                "decision": decision,
+            })
             return
         await self._error(
             websocket,
@@ -302,19 +372,49 @@ class WebChannel:
                 self._mapper.map_session_usage_snapshot(session_key, usage),
             )
 
+    async def _send_sandbox_snapshot(
+        self,
+        session_key: str,
+        websocket: WebSocketApi,
+    ) -> None:
+        snapshot = await self._commands.sandbox_snapshot(session_key)
+        if snapshot is not None:
+            await self._send_json(websocket, {
+                "type": "sandbox.updated",
+                "request_id": "",
+                "sandbox": snapshot,
+            })
+
+    async def _send_pending_approvals(
+        self,
+        session_key: str,
+        websocket: WebSocketApi,
+    ) -> None:
+        for request in await self._commands.pending_approvals(session_key):
+            await self._send_json(websocket, {
+                "type": "approval.requested",
+                "session_id": session_key,
+                "approval": request.to_wire(),
+            })
+
     async def _register(self, session_key: str, websocket: WebSocketApi) -> None:
         async with self._lock:
             self._connections.setdefault(session_key, set()).add(websocket)
             self._socket_send_locks.setdefault(websocket, asyncio.Lock())
+        await self._commands.set_session_available(session_key, True)
 
     async def _unregister(self, websocket: WebSocketApi) -> None:
+        unavailable: list[str] = []
         async with self._lock:
             for key in list(self._connections):
                 self._connections[key].discard(websocket)
                 if not self._connections[key]:
                     self._connections.pop(key, None)
+                    unavailable.append(key)
             # 发送锁使用弱引用保存；连接对象仍存活时始终复用同一把锁，断开且无引用后
             # 自动回收，避免清理与并发发送之间出现双锁竞态。
+        for session_key in unavailable:
+            await self._commands.set_session_available(session_key, False)
 
     async def _broadcast_mapped(self, mapped: MappedWebEvent) -> int:
         sent = 0

--- a/agent/event_bus.py
+++ b/agent/event_bus.py
@@ -141,6 +141,14 @@ class ToolCallCompleted:
 
 
 @dataclass(frozen=True, slots=True)
+class SandboxApprovalRequested:
+    """工具越权后等待当前会话的 Web 用户给出一次性决定。"""
+
+    session_key: str
+    request: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
 class TurnCommitted:
     """user 与 assistant 两条消息均持久化成功后的提交事件。"""
 
@@ -211,6 +219,7 @@ __all__ = [
     "EventBus",
     "EventHandler",
     "SessionUpdated",
+    "SandboxApprovalRequested",
     "StreamDeltaReady",
     "ToolCallCompleted",
     "ToolCallStarted",

--- a/agent/pipeline.py
+++ b/agent/pipeline.py
@@ -43,6 +43,7 @@ from agent.prompt_cache_log import PromptCacheLogWriter
 from agent.provider import ContextLengthError, LLMResponse, ProviderUsage
 from agent.skills import SkillsLoader, collect_skill_mentions
 from agent.tool_runtime import ToolRuntimeView
+from sandbox.guard import SandboxGuard
 from session.store import NewSessionEvent, NewSurfaceEvent
 from tools.base import normalize_tool_result
 from tools.registry import ToolRegistry
@@ -102,6 +103,7 @@ class Pipeline:
         max_iterations: int = 10,
         multimodal: bool = True,
         vl_available: bool = False,
+        sandbox_guard: SandboxGuard | None = None,
     ) -> None:
         self._provider = provider
         self._tools = tools
@@ -126,6 +128,7 @@ class Pipeline:
         # 接收 image_url；独立 VL 可用时则由现有 ReAct 工具链负责真正读图。
         self._multimodal = bool(multimodal)
         self._vl_available = bool(vl_available)
+        self._sandbox_guard = sandbox_guard
         # 中断快照只服务于当前进程内的停止/续跑语义，不进入 Session 或长期记忆。
         self._interrupt_snapshots: dict[str, dict[str, Any]] = {}
         # 只保存每个会话最近一次供应商 usage 锚点；完整快照由 SessionStore
@@ -1036,6 +1039,8 @@ class Pipeline:
                 execution_context: dict[str, Any] = tool_view.context
                 execution_context.update({
                     "session_key": message.session_key,
+                    "turn_id": turn_id,
+                    "call_id": call.id,
                     "channel": message.channel,
                     "chat_id": message.chat_id,
                     "request_time": str(message.metadata.get("request_time") or message.metadata.get("received_at") or ""),
@@ -1044,11 +1049,27 @@ class Pipeline:
                     # 搜索工具需要知道哪些 Schema 已在当前 Turn 可见，但不能
                     # 持有 View 本身，否则状态会重新泄漏到全局工具实例。
                     execution_context["excluded_names"] = set(tool_view.visible_names)
-                raw_result = await self._tools.execute(
-                    call.name,
-                    call.arguments,
-                    context=execution_context,
+                tool_meta = self._tools.get_metadata(call.name)
+                mcp_restricted = (
+                    self._sandbox_guard is not None
+                    and (
+                        (tool_meta is not None and tool_meta.source_type == "mcp")
+                        or call.name == "mcp_add"
+                    )
+                    and self._sandbox_guard.policy(message.session_key).mode
+                    != "danger-full-access"
                 )
+                if mcp_restricted:
+                    raw_result = (
+                        "错误：MCP 子进程属于受信任扩展，当前仅在经过风险确认的"
+                        "完全访问会话中可用"
+                    )
+                else:
+                    raw_result = await self._tools.execute(
+                        call.name,
+                        call.arguments,
+                        context=execution_context,
+                    )
                 result = normalize_tool_result(raw_result)
                 if call.name == "tool_search":
                     try:

--- a/agent/web_commands.py
+++ b/agent/web_commands.py
@@ -47,19 +47,41 @@ class WebCommandService:
         interrupt_controller: InterruptController,
         *,
         media_root: Path | None = None,
-        ensure_session: Callable[[str], Awaitable[object]] | None = None,
+        ensure_session: Callable[..., Awaitable[object]] | None = None,
+        sandbox_loader: Callable[[str], Awaitable[dict[str, Any] | None]] | None = None,
+        sandbox_mode_writer: Callable[[str, str], Awaitable[dict[str, Any]]] | None = None,
+        workspace_writer: Callable[[str, str | None], Awaitable[dict[str, Any]]] | None = None,
+        approvals: Any | None = None,
     ) -> None:
         self._bus = bus
         self._interrupt = interrupt_controller
         self._media_root = media_root.resolve() if media_root is not None else None
         self._ensure_session = ensure_session
+        self._sandbox_loader = sandbox_loader
+        self._sandbox_mode_writer = sandbox_mode_writer
+        self._workspace_writer = workspace_writer
+        self._approvals = approvals
 
-    async def create_session(self) -> str:
+    async def create_session(
+        self,
+        *,
+        workspace_id: str | None = None,
+        sandbox_mode: str = "read-only",
+        risk_confirmed: bool = False,
+    ) -> str:
         """先持久化空会话，使创建响应后的查询不会短暂返回 404。"""
 
+        _validate_sandbox_mode(sandbox_mode, risk_confirmed=risk_confirmed)
         session_key = f"web:{uuid4().hex}"
         if self._ensure_session is not None:
-            await self._ensure_session(session_key)
+            if workspace_id is None and sandbox_mode == "read-only":
+                await self._ensure_session(session_key)
+            else:
+                await self._ensure_session(
+                    session_key,
+                    workspace_id=workspace_id,
+                    sandbox_mode=sandbox_mode,
+                )
         return session_key
 
     async def prepare_message(
@@ -69,6 +91,9 @@ class WebCommandService:
         session_id: object,
         text: object,
         media: object,
+        workspace_id: str | None = None,
+        sandbox_mode: str = "read-only",
+        risk_confirmed: bool = False,
     ) -> PreparedWebMessage:
         content = str(text or "")
         attachments = _normalize_media(media)
@@ -83,7 +108,11 @@ class WebCommandService:
         created_session = session_key is None
         if session_key is None:
             # 校验全部完成后才创建，避免非法首轮请求留下空会话。
-            session_key = await self.create_session()
+            session_key = await self.create_session(
+                workspace_id=workspace_id,
+                sandbox_mode=sandbox_mode,
+                risk_confirmed=risk_confirmed,
+            )
         chat_id = session_key.split(":", 1)[1]
         message = InboundMessage(
             "web",
@@ -99,7 +128,69 @@ class WebCommandService:
         await self._bus.publish_inbound(prepared.message)
 
     async def stop_turn(self, session_key: str) -> InterruptResult:
+        if self._approvals is not None:
+            await self._approvals.cancel_session(session_key)
         return await self._interrupt.request_interrupt(session_key)
+
+    async def sandbox_snapshot(self, session_key: str) -> dict[str, Any] | None:
+        if self._sandbox_loader is None:
+            return None
+        return await self._sandbox_loader(session_key)
+
+    async def pending_approvals(self, session_key: str) -> list[Any]:
+        if self._approvals is None:
+            return []
+        return await self._approvals.pending_for_session(session_key)
+
+    async def set_session_available(self, session_key: str, available: bool) -> None:
+        if self._approvals is not None:
+            await self._approvals.set_session_available(session_key, available)
+
+    async def set_sandbox_mode(
+        self,
+        session_key: str,
+        sandbox_mode: str,
+        *,
+        risk_confirmed: bool = False,
+    ) -> dict[str, Any]:
+        _validate_sandbox_mode(sandbox_mode, risk_confirmed=risk_confirmed)
+        if self._sandbox_mode_writer is None:
+            raise WebCommandError("sandbox_unavailable", "沙箱权限服务不可用")
+        if self._session_busy(session_key):
+            raise WebCommandError("session_busy", "会话运行或排队期间不能切换权限")
+        try:
+            return await self._sandbox_mode_writer(session_key, sandbox_mode)
+        except (KeyError, ValueError) as error:
+            raise WebCommandError("invalid_sandbox", str(error)) from error
+
+    async def bind_workspace(
+        self,
+        session_key: str,
+        workspace_id: str | None,
+    ) -> dict[str, Any]:
+        if self._workspace_writer is None:
+            raise WebCommandError("sandbox_unavailable", "工作区服务不可用")
+        if self._session_busy(session_key):
+            raise WebCommandError("session_busy", "会话运行期间不能切换工作目录")
+        try:
+            return await self._workspace_writer(session_key, workspace_id)
+        except (KeyError, ValueError) as error:
+            raise WebCommandError("invalid_workspace", str(error)) from error
+
+    async def decide_approval(
+        self,
+        approval_id: str,
+        session_key: str,
+        decision: str,
+    ) -> None:
+        if self._approvals is None:
+            raise WebCommandError("approval_unavailable", "审批服务不可用")
+        if decision not in {"allowed-once", "rejected"}:
+            raise WebCommandError("invalid_approval", "审批结果无效")
+        try:
+            await self._approvals.decide(approval_id, session_key, decision)
+        except (KeyError, PermissionError, ValueError) as error:
+            raise WebCommandError("invalid_approval", str(error)) from error
 
     def get_active_turn_snapshot(self, session_key: str) -> dict[str, Any] | None:
         snapshotter = getattr(self._interrupt, "get_active_turn_snapshot", None)
@@ -107,6 +198,10 @@ class WebCommandService:
             return None
         snapshot = snapshotter(session_key)
         return dict(snapshot) if snapshot else None
+
+    def _session_busy(self, session_key: str) -> bool:
+        checker = getattr(self._interrupt, "is_session_busy", None)
+        return bool(checker(session_key)) if callable(checker) else False
 
     def _media_is_allowed(self, media: list[str]) -> bool:
         if not media or self._media_root is None:
@@ -130,6 +225,13 @@ def _normalize_media(value: object) -> list[str]:
         for item in value
         if isinstance(item, str) and item.strip()
     ]
+
+
+def _validate_sandbox_mode(mode: str, *, risk_confirmed: bool) -> None:
+    if mode not in {"read-only", "workspace-write", "danger-full-access"}:
+        raise WebCommandError("invalid_sandbox", f"不支持的沙箱权限：{mode or 'empty'}")
+    if mode == "danger-full-access" and not risk_confirmed:
+        raise WebCommandError("invalid_sandbox", "完全访问必须完成风险确认")
 
 
 def normalize_web_session_id(value: object) -> str | None:

--- a/agent/web_events.py
+++ b/agent/web_events.py
@@ -12,6 +12,7 @@ from agent.event_bus import (
     ContextCompactionFailed,
     ContextCompactionStarted,
     ContextUsageUpdated,
+    SandboxApprovalRequested,
     SessionUsageUpdated,
     SessionUpdated,
     StreamDeltaReady,
@@ -37,6 +38,7 @@ WebLifecycleEvent: TypeAlias = (
     | StreamDeltaReady
     | ToolCallStarted
     | ToolCallCompleted
+    | SandboxApprovalRequested
 )
 
 
@@ -198,6 +200,12 @@ class WebEventMapper:
                 "tool_name": event.tool_name,
                 "status": event.status,
                 "result_preview": event.result_preview,
+            })
+        if isinstance(event, SandboxApprovalRequested):
+            return _mapped(event.session_key, {
+                "type": "approval.requested",
+                "session_id": event.session_key,
+                "approval": dict(event.request),
             })
         raise TypeError(f"不支持的 Web 事件: {type(event).__name__}")
 

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -521,6 +521,17 @@ def create_fastapi_app(runtime: CoreRuntime | AppRuntime) -> FastAPI:
 
     @app.delete("/api/chat/workspaces/{workspace_id}", status_code=204)
     async def unregister_workspace(workspace_id: str) -> Response:
+        session_keys = application.core.sessions.store.list_workspace_session_keys(
+            workspace_id
+        )
+        if any(
+            application.core.agent_loop.is_session_busy(session_key)
+            for session_key in session_keys
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail="工作区仍有关联会话正在运行或排队，请结束后再移除",
+            )
         if not application.core.sessions.store.delete_workspace(workspace_id):
             raise HTTPException(status_code=404, detail="工作区不存在")
         # 删除关系可能让多个缓存策略失效；Policy 每次回源，不需要全局缓存失效。

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -22,7 +22,7 @@ from PIL import Image, UnidentifiedImageError
 from agent.agent_loop import AgentLoop
 from agent.channel import WebChannel
 from agent.config_models import Config
-from agent.event_bus import EventBus
+from agent.event_bus import EventBus, SandboxApprovalRequested
 from agent.message_bus import MessageBus
 from agent.mcp.manage_tools import McpAddTool, McpListTool, McpRemoveTool
 from agent.mcp.registry import McpServerRegistry
@@ -43,6 +43,11 @@ from proactive.soft_executor import SoftTaskExecutor
 from proactive.store import ProactiveStore
 from proactive.turn_service import ProactiveTurnService
 from session.manager import SessionManager
+from sandbox.approval import ApprovalCoordinator
+from sandbox.filesystem import FilesystemMutationBroker
+from sandbox.guard import SandboxGuard
+from sandbox.policy import SandboxPolicyResolver
+from sandbox.runtime import SandboxProcessRuntime, create_runtime_temp_root
 from tools import ToolRegistry, register_all
 from tools.schedule import (
     CancelScheduleTool,
@@ -165,6 +170,12 @@ class AppRuntime:
                 core.sessions.store.get_session_usage, session_key
             ),
             context_runtime_id=str(getattr(core.provider, "runtime_id", "") or ""),
+            sandbox_loader=lambda session_key: asyncio.to_thread(
+                core.sessions.store.get_session_sandbox, session_key
+            ),
+            sandbox_mode_writer=core.sessions.set_sandbox_mode,
+            workspace_writer=core.sessions.set_workspace,
+            approvals=core.sandbox_approvals,
         )
         self.maintenance = (
             MemoryMaintenanceLoop(
@@ -206,6 +217,7 @@ class AppRuntime:
             # 顺序与参考 AppRuntime 一致：先阻止新工作进入，再等待/取消执行任务，
             # 最后按所有权从上层服务向底层 HTTP/SQLite 资源释放。
             await _cleanup_step("web_channel.close", self.channel.close)
+            await _cleanup_step("sandbox_approvals.close", self.core.sandbox_approvals.close)
             await _cleanup_step("proactive_chat.close", self.core.proactive_chat.close)
             await _cleanup_step("proactive_scheduler.close", self.core.scheduler.close)
             await _cleanup_step("agent_loop.close", self.core.agent_loop.close)
@@ -213,6 +225,7 @@ class AppRuntime:
                 self.agent_task.cancel()
                 await asyncio.gather(self.agent_task, return_exceptions=True)
             await _cleanup_step("mcp_registry.shutdown", self.core.mcp_registry.shutdown)
+            await _cleanup_step("sandbox_runtime.close", self.core.sandbox_runtime.close)
             if self.maintenance is not None:
                 await _cleanup_step("memory_maintenance.close", self.maintenance.close)
             if self.core.memory is not None:
@@ -254,6 +267,10 @@ class CoreRuntime:
     scheduler: SchedulerService
     proactive_chat: ProactiveChatLoop
     proactive_tools: ProactiveToolFactory
+    sandbox_policy: SandboxPolicyResolver
+    sandbox_approvals: ApprovalCoordinator
+    sandbox_guard: SandboxGuard
+    sandbox_runtime: SandboxProcessRuntime
     vision_provider: Any | None = None
 
 
@@ -268,9 +285,6 @@ def build_core_runtime(
 
     root = Path(workspace).expanduser().resolve()
     root.mkdir(parents=True, exist_ok=True)
-    workdir = Path(config.agent.workdir).expanduser().resolve()
-    workdir.mkdir(parents=True, exist_ok=True)
-
     # 主 Provider 是应用级共享资源，由 Runtime 最终关闭；MemoryEngine 只借用它执行
     # QueryRewriter/Consolidation，不拥有其生命周期。
     main_provider = provider or LLMProvider(config.llm)
@@ -278,6 +292,22 @@ def build_core_runtime(
     events = EventBus()
     messages = MessageBus()
     proactive_store = ProactiveStore(root / "proactive.db")
+    sandbox_policy = SandboxPolicyResolver(
+        sessions.store,
+        data_root=root,
+        runtime_temp_root=create_runtime_temp_root(),
+    )
+    sandbox_approvals = ApprovalCoordinator(sessions.store)
+
+    async def publish_approval(request: Any) -> None:
+        await events.emit(
+            SandboxApprovalRequested(request.session_id, request.to_wire())
+        )
+
+    sandbox_approvals.set_publisher(publish_approval)
+    sandbox_guard = SandboxGuard(sandbox_policy, sandbox_approvals)
+    sandbox_runtime = SandboxProcessRuntime(sandbox_policy)
+    mutation_broker = FilesystemMutationBroker(sandbox_policy, sandbox_runtime)
 
     memory: MemoryEngine | None = None
     actual_embedder = embedder
@@ -300,13 +330,16 @@ def build_core_runtime(
     tools = ToolRegistry()
     register_all(
         tools,
-        allowed_dir=workdir,
+        allowed_dir=None,
         multimodal=config.llm.multimodal,
         vl_provider=vision_provider,
         vl_model=config.llm.vl.model if config.llm.vl else "",
         session_store=sessions.store,
         memory_engine=memory,
         skills=skills,
+        sandbox_guard=sandbox_guard,
+        sandbox_runtime=sandbox_runtime,
+        mutation_broker=mutation_broker,
     )
     # 提醒工具从当前 Turn 的系统执行上下文取得 session_key，模型不需要也不能
     # 选择其他 Web 会话作为目标。
@@ -356,6 +389,7 @@ def build_core_runtime(
         # 后者只通过 read_image_vision 工具读取本地上传路径。
         multimodal=config.llm.multimodal,
         vl_available=vision_provider is not None,
+        sandbox_guard=sandbox_guard,
     )
     agent_loop = AgentLoop(
         messages,
@@ -402,6 +436,10 @@ def build_core_runtime(
         scheduler=scheduler,
         proactive_chat=proactive_chat,
         proactive_tools=proactive_tools,
+        sandbox_policy=sandbox_policy,
+        sandbox_approvals=sandbox_approvals,
+        sandbox_guard=sandbox_guard,
+        sandbox_runtime=sandbox_runtime,
         vision_provider=vision_provider,
     )
 
@@ -463,6 +501,31 @@ def create_fastapi_app(runtime: CoreRuntime | AppRuntime) -> FastAPI:
         )
         return {"items": items, "total": total}
 
+    @app.get("/api/chat/workspaces")
+    def list_workspaces() -> dict[str, Any]:
+        return {"items": application.core.sessions.store.list_workspaces()}
+
+    @app.post("/api/chat/workspaces", status_code=201)
+    def register_workspace(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
+        path = str(payload.get("path") or "").strip()
+        if not path:
+            raise HTTPException(status_code=400, detail="工作目录路径不能为空")
+        try:
+            resolved = application.core.sandbox_policy.validate_workspace(path)
+            return application.core.sessions.store.create_workspace(
+                str(resolved),
+                str(payload.get("title") or ""),
+            )
+        except (OSError, ValueError, RuntimeError) as error:
+            raise HTTPException(status_code=422, detail=str(error)) from error
+
+    @app.delete("/api/chat/workspaces/{workspace_id}", status_code=204)
+    async def unregister_workspace(workspace_id: str) -> Response:
+        if not application.core.sessions.store.delete_workspace(workspace_id):
+            raise HTTPException(status_code=404, detail="工作区不存在")
+        # 删除关系可能让多个缓存策略失效；Policy 每次回源，不需要全局缓存失效。
+        return Response(status_code=204)
+
     @app.get("/api/chat/sessions/{session_key:path}/messages")
     def list_messages(
         session_key: str,
@@ -519,6 +582,14 @@ def create_fastapi_app(runtime: CoreRuntime | AppRuntime) -> FastAPI:
     @app.get("/api/chat/sessions/{session_key:path}/turns")
     def list_turns(session_key: str) -> dict[str, Any]:
         return {"items": application.core.sessions.store.list_chat_turns(session_key)}
+
+    @app.get("/api/chat/sessions/{session_key:path}/sandbox")
+    def get_session_sandbox(session_key: str) -> dict[str, Any]:
+        require_web_session(session_key)
+        snapshot = application.core.sessions.store.get_session_sandbox(session_key)
+        if snapshot is None:
+            raise HTTPException(status_code=404, detail="会话不存在")
+        return snapshot
 
     def require_web_session(session_key: str) -> None:
         """主动设置只属于当前 Web channel，禁止借 path 参数访问其他渠道。"""
@@ -620,8 +691,10 @@ def create_fastapi_app(runtime: CoreRuntime | AppRuntime) -> FastAPI:
         channel = application.core.config.channels.chat.channel_name
         if not session_key.startswith(f"{channel}:"):
             raise HTTPException(status_code=404, detail="会话不存在")
+        await application.core.sandbox_approvals.cancel_session(session_key)
         if not await application.core.sessions.delete(session_key):
             raise HTTPException(status_code=404, detail="会话不存在")
+        await application.core.sandbox_runtime.close_session(session_key)
         return Response(status_code=204)
 
     @app.post("/api/chat/uploads")

--- a/bootstrap/app.py
+++ b/bootstrap/app.py
@@ -32,6 +32,14 @@ from agent.prompt_block import SectionCache, SystemPromptBuilder, default_prompt
 from agent.prompt_cache_log import PromptCacheLogWriter
 from agent.provider import LLMProvider, create_vision_provider
 from agent.skills import SkillsLoader
+from bootstrap.native_folder_picker import (
+    DirectoryPicker,
+    NativeHostError,
+    NativeHostUnavailable,
+    NativePickerBusy,
+    WindowsDirectoryPicker,
+    is_loopback_client,
+)
 from memory.embedder import Embedder
 from memory.engine import MemoryEngine
 from proactive.agent_tools import ProactiveToolFactory
@@ -444,10 +452,15 @@ def build_core_runtime(
     )
 
 
-def create_fastapi_app(runtime: CoreRuntime | AppRuntime) -> FastAPI:
+def create_fastapi_app(
+    runtime: CoreRuntime | AppRuntime,
+    *,
+    directory_picker: DirectoryPicker | None = None,
+) -> FastAPI:
     """为已组装 Runtime 暴露 WebSocket 路由，不复制或隐式替换依赖。"""
 
     application = runtime if isinstance(runtime, AppRuntime) else AppRuntime(runtime)
+    host_directories = directory_picker or WindowsDirectoryPicker()
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
@@ -505,6 +518,34 @@ def create_fastapi_app(runtime: CoreRuntime | AppRuntime) -> FastAPI:
     def list_workspaces() -> dict[str, Any]:
         return {"items": application.core.sessions.store.list_workspaces()}
 
+    def require_local_host(request: Request) -> None:
+        client_host = request.client.host if request.client is not None else None
+        if not is_loopback_client(client_host):
+            raise HTTPException(
+                status_code=403,
+                detail="本机目录能力只允许从回环地址调用",
+            )
+
+    @app.post("/api/chat/workspaces/pick")
+    def pick_workspace_directory(request: Request) -> dict[str, str | None]:
+        """打开系统选择器；选择阶段不创建工作目录或会话记录。"""
+
+        require_local_host(request)
+        try:
+            selected = host_directories.pick_directory()
+            if selected is None:
+                return {"path": None}
+            resolved = application.core.sandbox_policy.validate_workspace(selected)
+            return {"path": str(resolved)}
+        except NativePickerBusy as error:
+            raise HTTPException(status_code=409, detail=str(error)) from error
+        except NativeHostUnavailable as error:
+            raise HTTPException(status_code=501, detail=str(error)) from error
+        except NativeHostError as error:
+            raise HTTPException(status_code=503, detail=str(error)) from error
+        except (OSError, ValueError, RuntimeError) as error:
+            raise HTTPException(status_code=422, detail=str(error)) from error
+
     @app.post("/api/chat/workspaces", status_code=201)
     def register_workspace(payload: dict[str, Any] = Body(...)) -> dict[str, Any]:
         path = str(payload.get("path") or "").strip()
@@ -518,6 +559,46 @@ def create_fastapi_app(runtime: CoreRuntime | AppRuntime) -> FastAPI:
             )
         except (OSError, ValueError, RuntimeError) as error:
             raise HTTPException(status_code=422, detail=str(error)) from error
+
+    @app.patch("/api/chat/workspaces/{workspace_id}")
+    def update_workspace(
+        workspace_id: str,
+        payload: dict[str, Any] = Body(...),
+    ) -> dict[str, Any]:
+        allowed = {"title", "pinned"}
+        if not payload or any(key not in allowed for key in payload):
+            raise HTTPException(status_code=400, detail="工作区更新字段无效")
+        title = payload.get("title") if "title" in payload else None
+        pinned = payload.get("pinned") if "pinned" in payload else None
+        if pinned is not None and not isinstance(pinned, bool):
+            raise HTTPException(status_code=400, detail="pinned 必须是布尔值")
+        try:
+            updated = application.core.sessions.store.update_workspace(
+                workspace_id,
+                title=title,
+                pinned=pinned,
+            )
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error)) from error
+        if updated is None:
+            raise HTTPException(status_code=404, detail="工作区不存在")
+        return updated
+
+    @app.post("/api/chat/workspaces/{workspace_id}/open", status_code=204)
+    def open_workspace(workspace_id: str, request: Request) -> Response:
+        require_local_host(request)
+        workspace = application.core.sessions.store.get_workspace(workspace_id)
+        if workspace is None:
+            raise HTTPException(status_code=404, detail="工作区不存在")
+        if not workspace["valid"]:
+            raise HTTPException(status_code=409, detail="工作区目录当前不可用")
+        try:
+            host_directories.open_directory(Path(str(workspace["canonical_path"])))
+        except NativeHostUnavailable as error:
+            raise HTTPException(status_code=501, detail=str(error)) from error
+        except NativeHostError as error:
+            raise HTTPException(status_code=503, detail=str(error)) from error
+        return Response(status_code=204)
 
     @app.delete("/api/chat/workspaces/{workspace_id}", status_code=204)
     async def unregister_workspace(workspace_id: str) -> Response:
@@ -673,26 +754,48 @@ def create_fastapi_app(runtime: CoreRuntime | AppRuntime) -> FastAPI:
         return Response(status_code=204)
 
     @app.patch("/api/chat/sessions/{session_key:path}")
-    async def rename_session(
+    async def update_session(
         session_key: str,
-        title: str = Body(embed=True),
-    ) -> dict[str, str]:
-        """修改会话展示标题；原始消息和长期记忆均不参与该操作。"""
+        payload: dict[str, Any] = Body(...),
+    ) -> dict[str, Any]:
+        """修改会话标题或目录内置顶状态，不改变对话活动时间。"""
 
-        clean_title = str(title).strip()
-        if not clean_title or len(clean_title) > 60:
-            raise HTTPException(status_code=400, detail="会话标题长度必须为 1-60 个字符")
+        allowed = {"title", "pinned"}
+        if len(payload) != 1 or any(key not in allowed for key in payload):
+            raise HTTPException(status_code=400, detail="会话更新字段无效")
         channel = application.core.config.channels.chat.channel_name
         if not session_key.startswith(f"{channel}:"):
             raise HTTPException(status_code=404, detail="会话不存在")
-        updated = await application.core.sessions.update_title(session_key, clean_title)
-        if updated is None:
+        if "title" in payload:
+            clean_title = str(payload.get("title") or "").strip()
+            if not clean_title or len(clean_title) > 60:
+                raise HTTPException(status_code=400, detail="会话标题长度必须为 1-60 个字符")
+            updated = await application.core.sessions.update_title(session_key, clean_title)
+            if updated is None:
+                raise HTTPException(status_code=404, detail="会话不存在")
+        if "pinned" in payload:
+            pinned = payload.get("pinned")
+            if not isinstance(pinned, bool):
+                raise HTTPException(status_code=400, detail="pinned 必须是布尔值")
+            try:
+                updated = await asyncio.to_thread(
+                    application.core.sessions.store.set_chat_session_pinned,
+                    session_key,
+                    pinned,
+                )
+            except ValueError as error:
+                raise HTTPException(status_code=409, detail=str(error)) from error
+            if updated is None:
+                raise HTTPException(status_code=404, detail="会话不存在")
+        meta = application.core.sessions.store.get_session_meta(session_key)
+        if meta is None:
             raise HTTPException(status_code=404, detail="会话不存在")
-        # 前端按最近活动时间分组，重命名也属于一次活动，必须把持久化后的时间一并返回。
         return {
             "key": session_key,
-            "title": clean_title,
-            "updated_at": str(updated["updated_at"]),
+            "title": str(meta.get("metadata", {}).get("title") or ""),
+            "updated_at": str(meta["updated_at"]),
+            "last_activity_at": str(meta.get("last_activity_at") or meta["created_at"]),
+            "pinned_at": meta.get("pinned_at"),
         }
 
     @app.delete("/api/chat/sessions/{session_key:path}", status_code=204)

--- a/bootstrap/native_folder_picker.py
+++ b/bootstrap/native_folder_picker.py
@@ -1,0 +1,241 @@
+"""Windows 原生目录选择与资源管理器 Host 能力。"""
+
+from __future__ import annotations
+
+import ctypes
+import ipaddress
+import os
+import sys
+import threading
+from ctypes import wintypes
+from pathlib import Path
+from typing import Protocol
+from uuid import UUID
+
+
+class NativeHostError(RuntimeError):
+    """本机 Host 能力执行失败。"""
+
+
+class NativeHostUnavailable(NativeHostError):
+    """当前平台不支持请求的 Host 能力。"""
+
+
+class NativePickerBusy(NativeHostError):
+    """已经有一个原生目录选择器等待用户操作。"""
+
+
+class DirectoryPicker(Protocol):
+    """供 FastAPI 注入和测试替换的最小目录选择接口。"""
+
+    def pick_directory(self) -> Path | None: ...
+
+    def open_directory(self, path: Path) -> None: ...
+
+
+class WindowsDirectoryPicker:
+    """串行打开 Windows IFileOpenDialog，取消时返回 None。"""
+
+    def __init__(self) -> None:
+        self._dialog_lock = threading.Lock()
+
+    def pick_directory(self) -> Path | None:
+        if sys.platform != "win32":
+            raise NativeHostUnavailable("原生目录选择器当前仅支持 Windows")
+        if not self._dialog_lock.acquire(blocking=False):
+            raise NativePickerBusy("已有目录选择窗口等待操作")
+        try:
+            selected = _pick_windows_directory()
+            return Path(selected) if selected else None
+        except NativeHostError:
+            raise
+        except Exception as error:
+            raise NativeHostError(f"Windows 目录选择器失败：{error}") from error
+        finally:
+            self._dialog_lock.release()
+
+    def open_directory(self, path: Path) -> None:
+        if sys.platform != "win32":
+            raise NativeHostUnavailable("在资源管理器中打开当前仅支持 Windows")
+        try:
+            os.startfile(str(path))  # type: ignore[attr-defined]
+        except OSError as error:
+            raise NativeHostError(f"无法在资源管理器中打开目录：{error}") from error
+
+
+def is_loopback_client(host: str | None) -> bool:
+    """只接受明确的回环地址，未知主机名按远程请求拒绝。"""
+
+    value = str(host or "").strip().split("%", 1)[0]
+    if value.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(value).is_loopback
+    except ValueError:
+        return False
+
+
+class _GUID(ctypes.Structure):
+    _fields_ = [
+        ("Data1", wintypes.DWORD),
+        ("Data2", wintypes.WORD),
+        ("Data3", wintypes.WORD),
+        ("Data4", ctypes.c_ubyte * 8),
+    ]
+
+    @classmethod
+    def parse(cls, value: str) -> _GUID:
+        raw = UUID(value).bytes_le
+        return cls(
+            int.from_bytes(raw[0:4], "little"),
+            int.from_bytes(raw[4:6], "little"),
+            int.from_bytes(raw[6:8], "little"),
+            (ctypes.c_ubyte * 8).from_buffer_copy(raw[8:]),
+        )
+
+
+_CLSID_FILE_OPEN_DIALOG = _GUID.parse("dc1c5a9c-e88a-4dde-a5a1-60f82a20aef7")
+_IID_FILE_OPEN_DIALOG = _GUID.parse("d57c7288-d4ad-4768-be02-9d969532d960")
+_CLSCTX_INPROC_SERVER = 0x1
+_COINIT_APARTMENTTHREADED = 0x2
+_FOS_PICKFOLDERS = 0x20
+_FOS_FORCEFILESYSTEM = 0x40
+_FOS_PATHMUSTEXIST = 0x800
+_FOS_DONTADDTORECENT = 0x02000000
+_SIGDN_FILESYSPATH = 0x80058000
+_ERROR_CANCELLED_HRESULT = ctypes.c_long(0x800704C7).value
+
+
+def _com_method(
+    instance: ctypes.c_void_p,
+    index: int,
+    restype: object,
+    *argtypes: object,
+):
+    vtable = ctypes.cast(
+        instance,
+        ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)),
+    ).contents
+    prototype = ctypes.WINFUNCTYPE(restype, ctypes.c_void_p, *argtypes)
+    function = prototype(vtable[index])
+    return lambda *args: function(instance, *args)
+
+
+def _check_hresult(result: int, operation: str) -> None:
+    if result < 0:
+        unsigned = ctypes.c_ulong(result).value
+        raise NativeHostError(f"{operation} 失败（HRESULT 0x{unsigned:08X}）")
+
+
+def _release(instance: ctypes.c_void_p | None) -> None:
+    if instance and instance.value:
+        _com_method(instance, 2, wintypes.ULONG)()
+
+
+def _foreground_window() -> wintypes.HWND | None:
+    """取得用户当前正在操作的窗口，供系统选择器建立 owner 关系。"""
+
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+    user32.GetForegroundWindow.argtypes = ()
+    user32.GetForegroundWindow.restype = wintypes.HWND
+    user32.IsWindow.argtypes = (wintypes.HWND,)
+    user32.IsWindow.restype = wintypes.BOOL
+    owner = user32.GetForegroundWindow()
+    return owner if owner and user32.IsWindow(owner) else None
+
+
+def _pick_windows_directory() -> str | None:
+    """在当前 STA 线程阻塞显示现代 Windows 文件夹选择器。"""
+
+    # HTTP Host 并不拥有浏览器窗口；显式绑定当前前台窗口可让系统对话框直接置前。
+    owner = _foreground_window()
+    ole32 = ctypes.OleDLL("ole32")
+    ole32.CoInitializeEx.argtypes = (ctypes.c_void_p, wintypes.DWORD)
+    ole32.CoInitializeEx.restype = ctypes.c_long
+    ole32.CoUninitialize.argtypes = ()
+    ole32.CoCreateInstance.argtypes = (
+        ctypes.POINTER(_GUID),
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.POINTER(_GUID),
+        ctypes.POINTER(ctypes.c_void_p),
+    )
+    ole32.CoCreateInstance.restype = ctypes.c_long
+    ole32.CoTaskMemFree.argtypes = (ctypes.c_void_p,)
+
+    initialized = ole32.CoInitializeEx(None, _COINIT_APARTMENTTHREADED)
+    _check_hresult(initialized, "初始化 Windows COM")
+    dialog = ctypes.c_void_p()
+    item = ctypes.c_void_p()
+    raw_path = ctypes.c_void_p()
+    try:
+        _check_hresult(
+            ole32.CoCreateInstance(
+                ctypes.byref(_CLSID_FILE_OPEN_DIALOG),
+                None,
+                _CLSCTX_INPROC_SERVER,
+                ctypes.byref(_IID_FILE_OPEN_DIALOG),
+                ctypes.byref(dialog),
+            ),
+            "创建 Windows 文件夹选择器",
+        )
+        options = wintypes.DWORD()
+        _check_hresult(
+            _com_method(dialog, 10, ctypes.c_long, ctypes.POINTER(wintypes.DWORD))(
+                ctypes.byref(options)
+            ),
+            "读取目录选择器选项",
+        )
+        options.value |= (
+            _FOS_PICKFOLDERS
+            | _FOS_FORCEFILESYSTEM
+            | _FOS_PATHMUSTEXIST
+            | _FOS_DONTADDTORECENT
+        )
+        _check_hresult(
+            _com_method(dialog, 9, ctypes.c_long, wintypes.DWORD)(options),
+            "设置目录选择器选项",
+        )
+        _check_hresult(
+            _com_method(dialog, 17, ctypes.c_long, wintypes.LPCWSTR)(
+                "选择 BeanAgent 工作目录"
+            ),
+            "设置目录选择器标题",
+        )
+        shown = _com_method(dialog, 3, ctypes.c_long, wintypes.HWND)(owner)
+        if shown == _ERROR_CANCELLED_HRESULT:
+            return None
+        _check_hresult(shown, "显示目录选择器")
+        _check_hresult(
+            _com_method(dialog, 20, ctypes.c_long, ctypes.POINTER(ctypes.c_void_p))(
+                ctypes.byref(item)
+            ),
+            "读取选中目录",
+        )
+        _check_hresult(
+            _com_method(
+                item,
+                5,
+                ctypes.c_long,
+                ctypes.c_int,
+                ctypes.POINTER(ctypes.c_void_p),
+            )(_SIGDN_FILESYSPATH, ctypes.byref(raw_path)),
+            "读取选中目录路径",
+        )
+        return ctypes.wstring_at(raw_path.value)
+    finally:
+        if raw_path.value:
+            ole32.CoTaskMemFree(raw_path)
+        _release(item)
+        _release(dialog)
+        ole32.CoUninitialize()
+
+
+__all__ = [
+    "DirectoryPicker",
+    "NativeHostError",
+    "NativeHostUnavailable",
+    "NativePickerBusy",
+    "WindowsDirectoryPicker",
+    "is_loopback_client",
+]

--- a/frontend/chat/src/App.test.tsx
+++ b/frontend/chat/src/App.test.tsx
@@ -328,9 +328,14 @@ it("工作区列表加载不到关联目录时仍显示原有会话", async () =
   expect(screen.getByRole("button", { name: "保留的会话" })).toBeVisible();
 });
 
-it("工作目录通过绝对路径注册且移除时明确保留磁盘文件", async () => {
+it("工作目录通过原生选择器注册且移除时明确保留磁盘文件", async () => {
+  let finishPicking: ((response: Response) => void) | undefined;
+  const picking = new Promise<Response>((resolve) => { finishPicking = resolve; });
   vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
+    if (url.endsWith("/api/chat/workspaces/pick") && init?.method === "POST") {
+      return picking;
+    }
     if (url.endsWith("/api/chat/workspaces") && init?.method === "POST") {
       const body = JSON.parse(String(init.body)) as { path: string; title: string };
       return { ok: true, json: async () => ({
@@ -347,12 +352,20 @@ it("工作目录通过绝对路径注册且移除时明确保留磁盘文件", a
   await screen.findByText("已连接");
 
   fireEvent.click(screen.getByRole("button", { name: "添加工作目录" }));
-  fireEvent.change(screen.getByLabelText("绝对路径"), { target: { value: "D:\\code\\bean" } });
+  fireEvent.click(screen.getByRole("button", { name: /选择 Bean 可读取和编辑的文件夹/ }));
+  expect(screen.getByRole("button", { name: /选择 Bean 可读取和编辑的文件夹/ })).toBeDisabled();
+  expect(screen.queryByText(/正在打开文件夹选择器/)).not.toBeInTheDocument();
+  await act(async () => {
+    finishPicking?.({ ok: true, json: async () => ({ path: "D:\\code\\bean" }) } as Response);
+    await picking;
+  });
+  await screen.findByText("D:\\code\\bean");
   fireEvent.change(screen.getByLabelText(/显示名称/), { target: { value: "Bean 工程" } });
   fireEvent.click(screen.getByRole("button", { name: "添加" }));
   expect(await screen.findByText("Bean 工程")).toBeVisible();
 
-  fireEvent.click(screen.getByRole("button", { name: "移除工作目录“Bean 工程”" }));
+  fireEvent.click(screen.getByRole("button", { name: "打开工作目录“Bean 工程”的菜单" }));
+  fireEvent.click(screen.getByRole("menuitem", { name: "移除工作目录" }));
   expect(screen.getByText(/磁盘上的目录和文件不会被删除/)).toBeVisible();
   fireEvent.click(screen.getByRole("button", { name: "确认移除" }));
   await waitFor(() => expect(screen.queryByText("Bean 工程")).not.toBeInTheDocument());
@@ -1050,31 +1063,30 @@ it("切回后台运行会话时恢复用户问题流式内容和工具状态", a
   expect(screen.queryByText("排队中 · 即将开始")).not.toBeInTheDocument();
 });
 
-it("会话列表使用最近更新时间分组", async () => {
+it("最近会话按对话活动时间倒序且不再创建时间小组", async () => {
   vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
     const payload = String(input).includes("/messages")
       ? { items: [], total: 0 }
       : {
-          items: [{
-            key: "web:first-time",
-            first_message_content: "固定创建时间",
-            created_at: "2026-01-02T10:00:00+08:00",
-            updated_at: "2026-06-10T10:00:00+08:00",
-          }],
-          total: 1,
+          items: [
+            { key: "web:older", first_message_content: "较早活动", created_at: "2026-06-01T10:00:00+08:00", updated_at: "2026-07-01T10:00:00+08:00", last_activity_at: "2026-06-10T10:00:00+08:00" },
+            { key: "web:newer", first_message_content: "较晚活动", created_at: "2026-01-02T10:00:00+08:00", updated_at: "2026-01-02T10:00:00+08:00", last_activity_at: "2026-07-10T10:00:00+08:00" },
+          ],
+          total: 2,
         };
     return { ok: true, json: async () => payload } as Response;
   }));
 
   const { container } = render(<App />);
 
-  await screen.findByText("固定创建时间");
-  expect(screen.getByText("2026-06", { selector: ".session-group-title" })).toBeVisible();
-  expect(screen.queryByText("2026-01", { selector: ".session-group-title" })).not.toBeInTheDocument();
+  const newer = await screen.findByRole("button", { name: "较晚活动" });
+  const older = screen.getByRole("button", { name: "较早活动" });
+  expect(newer.compareDocumentPosition(older) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  expect(container.querySelector(".session-group-title")).toBeNull();
   expect(container.querySelector(".session-row time")).toBeNull();
 });
 
-it("会话列表显示时间分组标题", async () => {
+it("最近分区保持在项目之后且会话按活动时间倒序", async () => {
   vi.useFakeTimers({ toFake: ["Date"] });
   vi.setSystemTime(new Date("2026-07-19T18:00:00+08:00"));
   vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
@@ -1090,9 +1102,81 @@ it("会话列表显示时间分组标题", async () => {
 
   render(<App />);
 
-  expect(await screen.findByText("今天", { selector: ".session-group-title" })).toBeVisible();
-  expect(screen.getByText("昨天", { selector: ".session-group-title" })).toBeVisible();
+  const today = await screen.findByRole("button", { name: "今天会话" });
+  const yesterday = screen.getByRole("button", { name: "昨天会话" });
+  expect(today.compareDocumentPosition(yesterday) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  expect(screen.getByRole("heading", { name: "最近" })).toBeVisible();
   vi.useRealTimers();
+});
+
+it("侧栏按置顶项目、普通项目和最近的固定规则排序", async () => {
+  const session = (
+    key: string,
+    title: string,
+    workspaceId: string | null,
+    activity: string,
+    pinnedAt: string | null = null,
+  ) => ({
+    key,
+    title,
+    created_at: activity,
+    updated_at: activity,
+    last_activity_at: activity,
+    pinned_at: pinnedAt,
+    message_count: 1,
+    first_message_content: title,
+    workspace_id: workspaceId,
+  });
+  const workspace = (
+    id: string,
+    title: string,
+    createdAt: string,
+    pinnedAt: string | null = null,
+  ) => ({
+    id,
+    title,
+    canonical_path: `D:/projects/${id}`,
+    created_at: createdAt,
+    updated_at: createdAt,
+    pinned_at: pinnedAt,
+    valid: true,
+  });
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.endsWith("/api/chat/workspaces")) {
+      return { ok: true, json: async () => ({ items: [
+        workspace("project-old", "旧项目", "2026-01-01T10:00:00+08:00"),
+        workspace("pinned-later", "后置顶", "2026-04-01T10:00:00+08:00", "2026-07-02T10:00:00+08:00"),
+        workspace("project-new", "新项目", "2026-06-01T10:00:00+08:00"),
+        workspace("pinned-first", "先置顶", "2026-03-01T10:00:00+08:00", "2026-07-01T10:00:00+08:00"),
+      ] }) } as Response;
+    }
+    if (url.includes("/api/chat/sessions")) {
+      return { ok: true, json: async () => ({ items: [
+        session("web:normal-old", "普通较早", "pinned-first", "2026-05-01T10:00:00+08:00"),
+        session("web:pinned-later", "后置顶会话", "pinned-first", "2026-08-01T10:00:00+08:00", "2026-07-04T10:00:00+08:00"),
+        session("web:recent", "最近会话", null, "2026-08-03T10:00:00+08:00"),
+        session("web:normal-new", "普通较新", "pinned-first", "2026-06-01T10:00:00+08:00"),
+        session("web:pinned-first", "先置顶会话", "pinned-first", "2026-04-01T10:00:00+08:00", "2026-07-03T10:00:00+08:00"),
+      ], total: 5 }) } as Response;
+    }
+    return { ok: true, json: async () => ({ items: [] }) } as Response;
+  }));
+
+  const { container } = render(<App />);
+  await screen.findByText("最近会话");
+
+  expect([...container.querySelectorAll(".sidebar-section-label")].map((node) => node.textContent)).toEqual([
+    "置顶", "项目", "最近",
+  ]);
+  expect([...container.querySelectorAll("[data-workspace-id]")].map((node) => node.getAttribute("data-workspace-id"))).toEqual([
+    "pinned-first", "pinned-later", "project-new", "project-old", "none",
+  ]);
+  const pinnedProject = container.querySelector('[data-workspace-id="pinned-first"]');
+  expect(pinnedProject).not.toBeNull();
+  expect([...pinnedProject!.querySelectorAll(".session-row-select")].map((node) => node.textContent)).toEqual([
+    "先置顶会话", "后置顶会话", "普通较新", "普通较早",
+  ]);
 });
 
 it("通过会话菜单重命名且不触发会话切换", async () => {

--- a/frontend/chat/src/App.test.tsx
+++ b/frontend/chat/src/App.test.tsx
@@ -128,6 +128,236 @@ it("首条消息发送后创建 Session 并保留用户消息", async () => {
   expect(screen.getByRole("button", { name: "新对话" })).toBeVisible();
 });
 
+it("新会话首条消息携带工作目录和工作区可写权限", async () => {
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.endsWith("/api/chat/workspaces")) {
+      return { ok: true, json: async () => ({ items: [{
+        id: "workspace-1", canonical_path: "D:/code/bean", title: "Bean 项目",
+        created_at: "2026-09-03T10:00:00+08:00", updated_at: "2026-09-03T10:00:00+08:00", valid: true,
+      }] }) } as Response;
+    }
+    return { ok: true, json: async () => ({ items: [], total: 0 }) } as Response;
+  }));
+  render(<App />);
+  await screen.findByText("已连接");
+
+  fireEvent.click(screen.getByRole("button", { name: "工作目录：无工作目录" }));
+  fireEvent.click(screen.getByRole("menuitemradio", { name: /Bean 项目/ }));
+  fireEvent.click(screen.getByRole("button", { name: "权限：只读" }));
+  fireEvent.click(screen.getByRole("menuitemradio", { name: /工作区可写/ }));
+  fireEvent.change(screen.getByPlaceholderText("输入消息，或附加文本与图片"), { target: { value: "检查工作区" } });
+  fireEvent.click(screen.getByRole("button", { name: "发送" }));
+
+  const socket = FakeWebSocket.instances[0];
+  await waitFor(() => expect(socket.sent.some((frame) => frame.type === "message.send")).toBe(true));
+  const frame = socket.sent.find((item) => item.type === "message.send");
+  expect(frame).toMatchObject({
+    workspace_id: "workspace-1",
+    sandbox_mode: "workspace-write",
+    text: "检查工作区",
+  });
+  expect(frame).not.toHaveProperty("risk_confirmed");
+});
+
+it("完全访问必须完成独立风险确认", async () => {
+  render(<App />);
+  await screen.findByText("已连接");
+
+  fireEvent.click(screen.getByRole("button", { name: "权限：只读" }));
+  fireEvent.click(screen.getByRole("menuitemradio", { name: /完全访问/ }));
+  const dialog = screen.getByRole("dialog", { name: "启用完全访问？" });
+  const confirm = within(dialog).getByRole("button", { name: "启用完全访问" });
+  expect(confirm).toBeDisabled();
+  fireEvent.click(within(dialog).getByRole("checkbox"));
+  expect(confirm).toBeEnabled();
+  fireEvent.click(confirm);
+
+  expect(screen.queryByRole("dialog", { name: "启用完全访问？" })).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "权限：完全访问" })).toBeVisible();
+});
+
+it("已有会话等待服务端快照后再更新权限", async () => {
+  window.history.replaceState({}, "", "/chat/sandbox");
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.endsWith("/api/chat/workspaces")) {
+      return { ok: true, json: async () => ({ items: [{
+        id: "workspace-1", canonical_path: "D:/code/bean", title: "Bean 项目",
+        created_at: "2026-09-03T10:00:00+08:00", updated_at: "2026-09-03T10:00:00+08:00", valid: true,
+      }] }) } as Response;
+    }
+    if (url.includes("/api/chat/sessions?page=")) {
+      return { ok: true, json: async () => ({ items: [{
+        key: "web:sandbox", title: "沙箱会话", first_message_content: "", message_count: 0,
+        created_at: "2026-09-03T10:00:00+08:00", updated_at: "2026-09-03T10:00:00+08:00",
+        workspace_id: "workspace-1", workspace_title: "Bean 项目", workspace_path: "D:/code/bean",
+        workspace_valid: true, sandbox_mode: "read-only",
+      }] }) } as Response;
+    }
+    return { ok: true, json: async () => ({ items: [], total: 0 }) } as Response;
+  }));
+  render(<App />);
+  await screen.findByRole("button", { name: "权限：只读" });
+  const socket = FakeWebSocket.instances[0];
+
+  fireEvent.click(screen.getByRole("button", { name: "权限：只读" }));
+  fireEvent.click(screen.getByRole("menuitemradio", { name: /工作区可写/ }));
+  const request = socket.sent.find((frame) => frame.type === "sandbox.mode.set");
+  expect(request).toMatchObject({ session_id: "web:sandbox", sandbox_mode: "workspace-write" });
+  expect(screen.getByRole("button", { name: "权限：只读" })).toBeDisabled();
+
+  act(() => socket.onmessage?.({ data: JSON.stringify({
+    type: "sandbox.updated",
+    request_id: request?.request_id,
+    sandbox: {
+      session_id: "web:sandbox", workspace_id: "workspace-1", cwd_snapshot: "D:/code/bean",
+      workspace_title: "Bean 项目", workspace_path: "D:/code/bean", workspace_valid: true,
+      sandbox_mode: "workspace-write", backend: "windows-acl", capability: "partial",
+    },
+  }) } as MessageEvent));
+  expect(screen.getByRole("button", { name: "权限：工作区可写" })).toBeEnabled();
+});
+
+it("审批面板锁定单次决定并等待服务端终态", async () => {
+  window.history.replaceState({}, "", "/chat/approval");
+  render(<App />);
+  await screen.findByText("已连接");
+  const socket = FakeWebSocket.instances[0];
+  const approval = {
+    id: "approval-1", session_id: "web:approval", turn_id: "turn-1", call_id: "call-1",
+    tool_name: "shell", operation: "执行完整 Shell 命令",
+    arguments: { command: "Set-Content D:\\outside.txt 'value'", cwd: "D:/code/bean" },
+    reason: "命令需要写入工作目录之外的位置", requested_mode: "danger-full-access",
+    fingerprint: "fingerprint", state: "pending", created_at: "2026-09-03T10:00:00+08:00",
+  };
+  act(() => {
+    socket.onmessage?.({ data: JSON.stringify({ type: "session.subscribed", request_id: "sub", session_id: "web:approval" }) } as MessageEvent);
+    socket.onmessage?.({ data: JSON.stringify({ type: "approval.requested", session_id: "web:approval", approval }) } as MessageEvent);
+  });
+
+  expect(screen.getByLabelText("待处理权限审批")).toBeVisible();
+  expect(screen.getByText("Set-Content D:\\outside.txt 'value'")).toBeVisible();
+  expect(screen.queryByPlaceholderText("输入消息，或附加文本与图片")).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: "仅允许本次" }));
+  expect(screen.getByRole("button", { name: "提交中…" })).toBeDisabled();
+  const decision = socket.sent.find((frame) => frame.type === "approval.decide");
+  expect(decision).toMatchObject({ approval_id: "approval-1", decision: "allowed-once" });
+
+  act(() => socket.onmessage?.({ data: JSON.stringify({
+    type: "approval.resolved", request_id: decision?.request_id, session_id: "web:approval",
+    approval_id: "approval-1", decision: "allowed-once",
+  }) } as MessageEvent));
+  expect(screen.getByPlaceholderText("输入消息，或附加文本与图片")).toBeVisible();
+});
+
+it("Turn 最终消息会清理未单独回执的审批", async () => {
+  window.history.replaceState({}, "", "/chat/approval-final");
+  render(<App />);
+  await screen.findByText("已连接");
+  const socket = FakeWebSocket.instances[0];
+  act(() => {
+    socket.onmessage?.({ data: JSON.stringify({
+      type: "approval.requested",
+      session_id: "web:approval-final",
+      approval: {
+        id: "approval-final", session_id: "web:approval-final", turn_id: "turn-final", call_id: "call-final",
+        tool_name: "shell", operation: "执行完整 Shell 命令", arguments: { command: "echo done" },
+        reason: "命令需要临时授权", requested_mode: "danger-full-access",
+        fingerprint: "fingerprint-final", state: "pending", created_at: "2026-09-03T10:00:00+08:00",
+      },
+    }) } as MessageEvent);
+  });
+  expect(screen.getByLabelText("待处理权限审批")).toBeVisible();
+
+  act(() => socket.onmessage?.({ data: JSON.stringify({
+    type: "message.final", session_id: "web:approval-final", turn_id: "turn-final", content: "已结束",
+  }) } as MessageEvent));
+
+  expect(screen.queryByLabelText("待处理权限审批")).not.toBeInTheDocument();
+  expect(screen.getByPlaceholderText("输入消息，或附加文本与图片")).toBeVisible();
+});
+
+it("浏览器历史切换会话时拒绝旧会话待审批", async () => {
+  window.history.replaceState({}, "", "/chat/history-approval");
+  render(<App />);
+  await screen.findByText("已连接");
+  const socket = FakeWebSocket.instances[0];
+  act(() => {
+    socket.onmessage?.({ data: JSON.stringify({
+      type: "approval.requested",
+      session_id: "web:history-approval",
+      approval: {
+        id: "approval-history", session_id: "web:history-approval", turn_id: "turn-history", call_id: "call-history",
+        tool_name: "filesystem", operation: "删除文件", arguments: { path: "D:\\outside.txt" },
+        reason: "删除操作需要临时授权", requested_mode: "danger-full-access",
+        fingerprint: "fingerprint-history", state: "pending", created_at: "2026-09-03T10:00:00+08:00",
+      },
+    }) } as MessageEvent);
+  });
+  expect(screen.getByLabelText("待处理权限审批")).toBeVisible();
+
+  window.history.pushState({}, "", "/chat/history-target");
+  act(() => window.dispatchEvent(new PopStateEvent("popstate")));
+
+  await waitFor(() => expect(socket.sent.some((frame) => (
+    frame.type === "approval.decide"
+    && frame.session_id === "web:history-approval"
+    && frame.approval_id === "approval-history"
+    && frame.decision === "rejected"
+  ))).toBe(true));
+});
+
+it("工作区列表加载不到关联目录时仍显示原有会话", async () => {
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/api/chat/sessions?page=")) {
+      return { ok: true, json: async () => ({ items: [{
+        key: "web:orphaned-workspace", title: "保留的会话", first_message_content: "", message_count: 1,
+        created_at: "2026-09-03T10:00:00+08:00", updated_at: "2026-09-03T10:00:00+08:00",
+        workspace_id: "missing-workspace", workspace_title: "已丢失工程", workspace_path: "D:/missing/project",
+        workspace_valid: false, sandbox_mode: "read-only",
+      }], total: 1 }) } as Response;
+    }
+    return { ok: true, json: async () => ({ items: [], total: 0 }) } as Response;
+  }));
+
+  render(<App />);
+
+  expect(await screen.findByText("已丢失工程")).toBeVisible();
+  expect(screen.getByRole("button", { name: "保留的会话" })).toBeVisible();
+});
+
+it("工作目录通过绝对路径注册且移除时明确保留磁盘文件", async () => {
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.endsWith("/api/chat/workspaces") && init?.method === "POST") {
+      const body = JSON.parse(String(init.body)) as { path: string; title: string };
+      return { ok: true, json: async () => ({
+        id: "workspace-added", canonical_path: body.path, title: body.title,
+        created_at: "2026-09-03T10:00:00+08:00", updated_at: "2026-09-03T10:00:00+08:00", valid: true,
+      }) } as Response;
+    }
+    if (url.includes("/api/chat/workspaces/workspace-added") && init?.method === "DELETE") {
+      return { ok: true } as Response;
+    }
+    return { ok: true, json: async () => ({ items: [], total: 0 }) } as Response;
+  }));
+  render(<App />);
+  await screen.findByText("已连接");
+
+  fireEvent.click(screen.getByRole("button", { name: "添加工作目录" }));
+  fireEvent.change(screen.getByLabelText("绝对路径"), { target: { value: "D:\\code\\bean" } });
+  fireEvent.change(screen.getByLabelText(/显示名称/), { target: { value: "Bean 工程" } });
+  fireEvent.click(screen.getByRole("button", { name: "添加" }));
+  expect(await screen.findByText("Bean 工程")).toBeVisible();
+
+  fireEvent.click(screen.getByRole("button", { name: "移除工作目录“Bean 工程”" }));
+  expect(screen.getByText(/磁盘上的目录和文件不会被删除/)).toBeVisible();
+  fireEvent.click(screen.getByRole("button", { name: "确认移除" }));
+  await waitFor(() => expect(screen.queryByText("Bean 工程")).not.toBeInTheDocument());
+});
+
 it("中断消息只显示状态标签，不渲染持久化占位正文", async () => {
   window.history.replaceState({}, "", "/chat/interrupted");
   vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {

--- a/frontend/chat/src/App.tsx
+++ b/frontend/chat/src/App.tsx
@@ -16,35 +16,33 @@ import {
   Menu,
   MessageSquarePlus,
   Mic,
-  MoreHorizontal,
   Monitor,
   Moon,
   Paperclip,
-  Pencil,
   PlugZap,
   RefreshCw,
   SendHorizontal,
   Sun,
-  Trash2,
   Wrench,
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import type { ComponentPropsWithoutRef, CSSProperties, ReactNode } from "react";
+import type { ComponentPropsWithoutRef, CSSProperties } from "react";
 import { Streamdown } from "streamdown";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import type { StickToBottomContext } from "use-stick-to-bottom";
 
-import { deleteReminder, deleteSession, fetchMessagePage, fetchMessagesAroundPage, fetchNotifications, fetchOlderMessages, fetchProactiveSettings, fetchReminders, fetchSessions, fetchTurns, mediaUrl, renameSession, saveProactiveSettings, uploadAttachment } from "./api";
+import { deleteSession, deleteWorkspace, fetchMessagePage, fetchMessagesAroundPage, fetchNotifications, fetchOlderMessages, fetchSessions, fetchTurns, fetchWorkspaces, mediaUrl, registerWorkspace, renameSession, uploadAttachment } from "./api";
 import { idleTurnState, initialChatState, notificationRowsToMessages, reduceChatFrame, rowsToMessages } from "./chatReducer";
 import { composeTimeline, reconcileMessages } from "./timeline";
 import { parseMemoryCitations } from "./citations";
 import type { MemoryCitation } from "./citations";
 import { MermaidBlock } from "./MermaidBlock";
+import { ApprovalPanel, PermissionSelector, WorkspaceSelector } from "./SandboxControls";
+import { SessionSidebar } from "./SessionSidebar";
 import { pathForSession, routeKey, sessionFromPath } from "./chatRoute";
-import { groupSessionsByUpdatedAt } from "./sessionGroups";
-import type { ChatFrame, ChatMessage, ConnectionStatus, ContextUsage, MessageRow, ProactiveSettings, ScheduledReminder, SessionSummary, SessionUsage, ToolActivity, TurnNavigationEntry } from "./types";
+import type { ApprovalRequest, ChatFrame, ChatMessage, ConnectionStatus, ContextUsage, MessageRow, SandboxMode, SandboxSnapshot, SessionSummary, SessionUsage, ToolActivity, TurnNavigationEntry, Workspace } from "./types";
 import { groupMessagesIntoNavigationTurns, TurnNavigator, turnsFromMessages } from "./TurnNavigator";
 import { BeanWebSocketClient } from "./websocketClient";
 
@@ -182,6 +180,13 @@ export function App() {
   const [routeSession, setRouteSession] = useState(initialSession);
   const [connection, setConnection] = useState<ConnectionStatus>("connecting");
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [sandboxBySession, setSandboxBySession] = useState<Record<string, SandboxSnapshot>>({});
+  const [pendingApprovals, setPendingApprovals] = useState<Record<string, ApprovalRequest[]>>({});
+  const [approvalDecisionRequests, setApprovalDecisionRequests] = useState<Record<string, string>>({});
+  const [sandboxRequest, setSandboxRequest] = useState<{ id: string; sessionId: string } | null>(null);
+  const [newSessionWorkspaceId, setNewSessionWorkspaceId] = useState<string | null>(null);
+  const [newSessionMode, setNewSessionMode] = useState<SandboxMode>("read-only");
   const [turnsBySession, setTurnsBySession] = useState<Record<string, TurnNavigationEntry[]>>({});
   const [requestedTurnId, setRequestedTurnId] = useState("");
   const [notificationsBySession, setNotificationsBySession] = useState<Record<string, ChatMessage[]>>({});
@@ -206,11 +211,24 @@ export function App() {
   const compactionStartedAtRef = useRef<Record<string, number>>({});
   const compactionNoticeTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   const routeSessionRef = useRef(routeSession);
+  const workspacesRef = useRef(workspaces);
+  const pendingApprovalsRef = useRef(pendingApprovals);
+  const approvalDecisionRequestsRef = useRef(approvalDecisionRequests);
+  const sandboxRequestRef = useRef(sandboxRequest);
+  const newSessionConfigRef = useRef<{ workspaceId: string | null; mode: SandboxMode }>({
+    workspaceId: null,
+    mode: "read-only",
+  });
   const sessionLoadVersionsRef = useRef<Record<string, number>>({});
   const reloadSessionRef = useRef<(sessionId: string) => void>(() => undefined);
   chatRef.current = chat;
   messageWindowsRef.current = messageWindows;
   routeSessionRef.current = routeSession;
+  workspacesRef.current = workspaces;
+  pendingApprovalsRef.current = pendingApprovals;
+  approvalDecisionRequestsRef.current = approvalDecisionRequests;
+  sandboxRequestRef.current = sandboxRequest;
+  newSessionConfigRef.current = { workspaceId: newSessionWorkspaceId, mode: newSessionMode };
 
   useEffect(() => () => {
     for (const timer of Object.values(compactionNoticeTimersRef.current)) clearTimeout(timer);
@@ -219,6 +237,18 @@ export function App() {
   const currentTurn = chat.turnStates[chat.sessionId] ?? idleTurnState;
   const currentContextUsage = chat.contextUsage[chat.sessionId];
   const currentSessionUsage = chat.sessionUsage[chat.sessionId];
+  const currentSessionSummary = sessions.find((session) => session.key === chat.sessionId);
+  const currentSandbox = sandboxBySession[chat.sessionId];
+  const currentWorkspaceId = chat.sessionId
+    ? (currentSandbox?.workspace_id ?? currentSessionSummary?.workspace_id ?? null)
+    : newSessionWorkspaceId;
+  const currentSandboxMode = chat.sessionId
+    ? (currentSandbox?.sandbox_mode ?? currentSessionSummary?.sandbox_mode ?? "read-only")
+    : newSessionMode;
+  const currentWorkspaceValid = chat.sessionId
+    ? (currentSandbox?.workspace_valid ?? currentSessionSummary?.workspace_valid ?? true)
+    : (workspaces.find((workspace) => workspace.id === newSessionWorkspaceId)?.valid ?? true);
+  const currentApproval = pendingApprovals[chat.sessionId]?.[0];
   const turnActive = currentTurn.status === "submitting" || currentTurn.status === "queued" || currentTurn.status === "running" || currentTurn.status === "compacting";
   const restoringSession = Boolean(chat.sessionId && loadingSessionId === chat.sessionId && chat.messages.length === 0);
   const displayMessages = useMemo(() => composeTimeline(
@@ -275,6 +305,14 @@ export function App() {
     }
   }, []);
 
+  const refreshWorkspaces = useCallback(async () => {
+    try {
+      setWorkspaces(await fetchWorkspaces());
+    } catch (error) {
+      dispatch(errorFrame(error));
+    }
+  }, []);
+
   const refreshTurnPreviews = useCallback(async (sessionId: string) => {
     if (!sessionId) return;
     try {
@@ -297,9 +335,84 @@ export function App() {
     return true;
   }, []);
 
+  const clearApprovalsForSession = useCallback((sessionId: string) => {
+    const approvalIds = new Set(
+      (pendingApprovalsRef.current[sessionId] ?? []).map((approval) => approval.id),
+    );
+    const nextApprovals = { ...pendingApprovalsRef.current, [sessionId]: [] };
+    pendingApprovalsRef.current = nextApprovals;
+    setPendingApprovals(nextApprovals);
+    if (!approvalIds.size) return;
+    const nextRequests = Object.fromEntries(
+      Object.entries(approvalDecisionRequestsRef.current)
+        .filter(([approvalId]) => !approvalIds.has(approvalId)),
+    );
+    approvalDecisionRequestsRef.current = nextRequests;
+    setApprovalDecisionRequests(nextRequests);
+  }, []);
+
   const handleFrame = useCallback((frame: ChatFrame) => {
     if (handleNotificationFrame(frame)) return;
     dispatch(frame);
+    if (frame.type === "session.subscribed") {
+      // 服务端会在订阅确认后重放当前 pending；先丢弃旧缓存，避免重连产生重复审批卡片。
+      clearApprovalsForSession(frame.session_id);
+    }
+    if (frame.type === "sandbox.updated") {
+      const snapshot = frame.sandbox;
+      setSandboxBySession((current) => ({ ...current, [snapshot.session_id]: snapshot }));
+      setSessions((current) => current.map((session) => session.key === snapshot.session_id ? {
+        ...session,
+        workspace_id: snapshot.workspace_id,
+        cwd_snapshot: snapshot.cwd_snapshot,
+        workspace_title: snapshot.workspace_title,
+        workspace_path: snapshot.workspace_path,
+        workspace_valid: snapshot.workspace_valid,
+        sandbox_mode: snapshot.sandbox_mode,
+      } : session));
+      if (frame.request_id && sandboxRequestRef.current?.id === frame.request_id) {
+        sandboxRequestRef.current = null;
+        setSandboxRequest(null);
+      }
+    }
+    if (frame.type === "approval.requested") {
+      const existing = pendingApprovalsRef.current[frame.session_id] ?? [];
+      const nextApprovals = {
+        ...pendingApprovalsRef.current,
+        [frame.session_id]: existing.some((item) => item.id === frame.approval.id)
+          ? existing.map((item) => item.id === frame.approval.id ? frame.approval : item)
+          : [...existing, frame.approval],
+      };
+      pendingApprovalsRef.current = nextApprovals;
+      setPendingApprovals(nextApprovals);
+    }
+    if (frame.type === "approval.resolved") {
+      const nextApprovals = {
+        ...pendingApprovalsRef.current,
+        [frame.session_id]: (pendingApprovalsRef.current[frame.session_id] ?? [])
+          .filter((item) => item.id !== frame.approval_id),
+      };
+      pendingApprovalsRef.current = nextApprovals;
+      setPendingApprovals(nextApprovals);
+      const nextRequests = { ...approvalDecisionRequestsRef.current };
+      delete nextRequests[frame.approval_id];
+      approvalDecisionRequestsRef.current = nextRequests;
+      setApprovalDecisionRequests(nextRequests);
+    }
+    if (frame.type === "error") {
+      if (frame.request_id && sandboxRequestRef.current?.id === frame.request_id) {
+        sandboxRequestRef.current = null;
+        setSandboxRequest(null);
+      }
+      const approvalId = Object.entries(approvalDecisionRequestsRef.current)
+        .find(([, requestId]) => requestId === frame.request_id)?.[0];
+      if (approvalId) {
+        const nextRequests = { ...approvalDecisionRequestsRef.current };
+        delete nextRequests[approvalId];
+        approvalDecisionRequestsRef.current = nextRequests;
+        setApprovalDecisionRequests(nextRequests);
+      }
+    }
     if (frame.type === "context.compaction.started") {
       compactionStartedAtRef.current[frame.session_id] = Date.now();
       const previousTimer = compactionNoticeTimersRef.current[frame.session_id];
@@ -340,6 +453,11 @@ export function App() {
             updated_at: createdAt,
             message_count: 0,
             first_message_content: "",
+            workspace_id: newSessionConfigRef.current.workspaceId,
+            workspace_title: workspacesRef.current.find((workspace) => workspace.id === newSessionConfigRef.current.workspaceId)?.title ?? null,
+            workspace_path: workspacesRef.current.find((workspace) => workspace.id === newSessionConfigRef.current.workspaceId)?.canonical_path ?? null,
+            workspace_valid: workspacesRef.current.find((workspace) => workspace.id === newSessionConfigRef.current.workspaceId)?.valid ?? false,
+            sandbox_mode: newSessionConfigRef.current.mode,
           }, ...current]);
     }
     if (frame.type === "session.updated") {
@@ -355,6 +473,8 @@ export function App() {
       )));
     }
     if (frame.type === "message.final") {
+      // cancelled/unavailable 审批不一定另发 resolved；Turn 结束时必须让 composer 收敛。
+      clearApprovalsForSession(frame.session_id);
       void refreshSessions();
       void refreshTurnPreviews(frame.session_id);
     }
@@ -362,8 +482,9 @@ export function App() {
       // 后端发送该帧前已完成中断轮持久化。立刻用带 seq 的权威行替换本地草稿，
       // 避免连续中断时多个无 seq 草稿按客户端时间错序。
       reloadSessionRef.current(frame.session_id);
+      clearApprovalsForSession(frame.session_id);
     }
-  }, [handleNotificationFrame, refreshSessions, refreshTurnPreviews]);
+  }, [clearApprovalsForSession, handleNotificationFrame, refreshSessions, refreshTurnPreviews]);
 
   useEffect(() => {
     const client = new BeanWebSocketClient({
@@ -375,8 +496,9 @@ export function App() {
     clientRef.current = client;
     client.connect();
     void refreshSessions();
+    void refreshWorkspaces();
     return () => client.close();
-  }, [handleFrame, refreshSessions]);
+  }, [handleFrame, refreshSessions, refreshWorkspaces]);
 
   useEffect(() => {
     if (connection !== "connected" || !chat.sessionId) return;
@@ -430,8 +552,44 @@ export function App() {
     void loadSession(sessionId, false);
   };
 
-  const createSession = () => {
+  const decideApproval = useCallback((approval: ApprovalRequest, decision: "allowed-once" | "rejected") => {
+    if (approvalDecisionRequestsRef.current[approval.id]) return;
+    const requestId = crypto.randomUUID();
+    const nextRequests = { ...approvalDecisionRequestsRef.current, [approval.id]: requestId };
+    approvalDecisionRequestsRef.current = nextRequests;
+    setApprovalDecisionRequests(nextRequests);
+    const sent = clientRef.current?.send({
+      type: "approval.decide",
+      request_id: requestId,
+      session_id: approval.session_id,
+      approval_id: approval.id,
+      decision,
+    });
+    if (!sent) {
+      const currentRequests = { ...approvalDecisionRequestsRef.current };
+      delete currentRequests[approval.id];
+      approvalDecisionRequestsRef.current = currentRequests;
+      setApprovalDecisionRequests(currentRequests);
+      dispatch({
+        type: "error",
+        request_id: requestId,
+        session_id: approval.session_id,
+        code: "closed",
+        message: "审批结果未发送，连接已断开",
+      });
+      return;
+    }
+  }, []);
+
+  const rejectPendingApprovals = useCallback((sessionId: string) => {
+    for (const approval of pendingApprovalsRef.current[sessionId] ?? []) {
+      if (!approvalDecisionRequestsRef.current[approval.id]) decideApproval(approval, "rejected");
+    }
+  }, [decideApproval]);
+
+  const createSession = (workspaceId: string | null = null) => {
     if (connection !== "connected") return;
+    if (chat.sessionId) rejectPendingApprovals(chat.sessionId);
     setLoadingSessionId("");
     localStorage.removeItem(SESSION_STORAGE_KEY);
     window.history.pushState({}, "", "/");
@@ -443,16 +601,115 @@ export function App() {
     setFileDrafts((current) => ({ ...current, [routeKey("")]: [] }));
     setInput("");
     setFiles([]);
+    setNewSessionWorkspaceId(workspaceId);
+    setNewSessionMode("read-only");
     setSidebarOpen(false);
   };
 
   const selectSession = (sessionId: string) => {
+    if (chat.sessionId && chat.sessionId !== sessionId) rejectPendingApprovals(chat.sessionId);
     window.history.pushState({}, "", pathForSession(sessionId));
     routeSessionRef.current = sessionId;
     setRouteSession(sessionId);
     setInput(textDrafts[routeKey(sessionId)] ?? "");
     setFiles(fileDrafts[routeKey(sessionId)] ?? []);
     void loadSession(sessionId);
+  };
+
+  const handleRegisterWorkspace = async (path: string, title: string) => {
+    try {
+      const workspace = await registerWorkspace(path, title);
+      setWorkspaces((current) => [workspace, ...current.filter((item) => item.id !== workspace.id)]);
+      return workspace;
+    } catch (error) {
+      dispatch(errorFrame(error));
+      throw error;
+    }
+  };
+
+  const handleDeleteWorkspace = async (workspaceId: string) => {
+    try {
+      await deleteWorkspace(workspaceId);
+      setWorkspaces((current) => current.filter((workspace) => workspace.id !== workspaceId));
+      setSessions((current) => current.map((session) => session.workspace_id === workspaceId ? {
+        ...session,
+        workspace_id: null,
+        cwd_snapshot: null,
+        workspace_title: null,
+        workspace_path: null,
+        workspace_valid: false,
+        sandbox_mode: session.sandbox_mode === "workspace-write" ? "read-only" : session.sandbox_mode,
+      } : session));
+      setSandboxBySession((current) => Object.fromEntries(Object.entries(current).map(([sessionId, snapshot]) => (
+        snapshot.workspace_id === workspaceId
+          ? [sessionId, {
+              ...snapshot,
+              workspace_id: null,
+              cwd_snapshot: null,
+              workspace_title: null,
+              workspace_path: null,
+              workspace_valid: false,
+              sandbox_mode: snapshot.sandbox_mode === "workspace-write" ? "read-only" : snapshot.sandbox_mode,
+            }]
+          : [sessionId, snapshot]
+      ))));
+      if (newSessionWorkspaceId === workspaceId) {
+        setNewSessionWorkspaceId(null);
+        if (newSessionMode === "workspace-write") setNewSessionMode("read-only");
+      }
+    } catch (error) {
+      dispatch(errorFrame(error));
+      throw error;
+    }
+  };
+
+  const handleWorkspaceChange = (workspaceId: string | null) => {
+    if (!chat.sessionId) {
+      setNewSessionWorkspaceId(workspaceId);
+      if (workspaceId === null && newSessionMode === "workspace-write") setNewSessionMode("read-only");
+      return;
+    }
+    const requestId = crypto.randomUUID();
+    const request = { id: requestId, sessionId: chat.sessionId };
+    sandboxRequestRef.current = request;
+    setSandboxRequest(request);
+    const sent = clientRef.current?.send({
+      type: "workspace.bind",
+      request_id: requestId,
+      session_id: chat.sessionId,
+      workspace_id: workspaceId,
+    });
+    if (!sent) {
+      sandboxRequestRef.current = null;
+      setSandboxRequest(null);
+      dispatch({ type: "error", request_id: requestId, session_id: chat.sessionId, code: "closed", message: "工作目录未更新，连接已断开" });
+      return;
+    }
+  };
+
+  const handleSandboxModeChange = (mode: SandboxMode, riskConfirmed = false) => {
+    if (mode === "workspace-write" && currentWorkspaceId === null) return;
+    if (!chat.sessionId) {
+      setNewSessionMode(mode);
+      return;
+    }
+    const requestId = crypto.randomUUID();
+    const request = { id: requestId, sessionId: chat.sessionId };
+    sandboxRequestRef.current = request;
+    setSandboxRequest(request);
+    const sent = clientRef.current?.send({
+      type: "sandbox.mode.set",
+      request_id: requestId,
+      session_id: chat.sessionId,
+      sandbox_mode: mode,
+      ...(mode === "danger-full-access" ? { risk_confirmed: riskConfirmed } : {}),
+    });
+    if (!sent) {
+      sandboxRequestRef.current = null;
+      setSandboxRequest(null);
+      dispatch({ type: "error", request_id: requestId, session_id: chat.sessionId, code: "closed", message: "会话权限未更新，连接已断开" });
+      return;
+    }
   };
 
   const handleTurnRequest = useCallback(async (turn: TurnNavigationEntry) => {
@@ -638,6 +895,10 @@ export function App() {
   useEffect(() => {
     const handlePopState = () => {
       const sessionId = sessionFromPath(window.location.pathname);
+      const previousSessionId = chatRef.current.sessionId;
+      if (previousSessionId && previousSessionId !== sessionId) {
+        rejectPendingApprovals(previousSessionId);
+      }
       routeSessionRef.current = sessionId;
       setRouteSession(sessionId);
       setInput(textDrafts[routeKey(sessionId)] ?? "");
@@ -650,7 +911,7 @@ export function App() {
     };
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
-  }, [connection, fileDrafts, textDrafts]);
+  }, [connection, fileDrafts, rejectPendingApprovals, textDrafts]);
 
   const handleRenameSession = async (sessionId: string, title: string) => {
     try {
@@ -692,6 +953,11 @@ export function App() {
         type: "message.send",
         request_id: requestId,
         ...(sessionId ? { session_id: sessionId } : {}),
+        ...(!sessionId ? {
+          workspace_id: newSessionWorkspaceId,
+          sandbox_mode: newSessionMode,
+          ...(newSessionMode === "danger-full-access" ? { risk_confirmed: true } : {}),
+        } : {}),
         text: cleanText,
         media: uploaded.map((item) => item.upload_path),
       });
@@ -756,8 +1022,11 @@ export function App() {
     <SessionSidebar
       activeSessionId={chat.sessionId}
       sessions={sessions}
+      workspaces={workspaces}
       onCreate={createSession}
       onDelete={handleDeleteSession}
+      onDeleteWorkspace={handleDeleteWorkspace}
+      onRegisterWorkspace={handleRegisterWorkspace}
       onRename={handleRenameSession}
       onSelect={selectSession}
     />
@@ -867,30 +1136,48 @@ export function App() {
           />
         </StickToBottom>
 
-        <Composer
-          active={turnActive}
-          turnStatus={currentTurn.status}
-          queuePosition={currentTurn.queuePosition}
-          connected={connection === "connected"}
-          files={files}
-          input={input}
-          sessionId={chat.sessionId}
-          contextUsage={currentContextUsage}
-          sessionUsage={currentSessionUsage}
-          compacting={currentTurn.status === "compacting"
-            || (compactionNotice.sessionId === chat.sessionId && compactionNotice.visible)}
-          sending={sending}
-          onFiles={(next) => {
-            setFiles(next);
-            setFileDrafts((current) => ({ ...current, [routeKey(routeSession)]: next }));
-          }}
-          onInput={(value) => {
-            setInput(value);
-            setTextDrafts((current) => ({ ...current, [routeKey(routeSession)]: value }));
-          }}
-          onSend={() => void submit()}
-          onStop={stopTurn}
-        />
+        {currentApproval ? (
+          <ApprovalPanel
+            approval={currentApproval}
+            submitting={Boolean(approvalDecisionRequests[currentApproval.id])}
+            onDecide={(decision) => decideApproval(currentApproval, decision)}
+          />
+        ) : (
+          <Composer
+            active={turnActive}
+            turnStatus={currentTurn.status}
+            queuePosition={currentTurn.queuePosition}
+            connected={connection === "connected"}
+            files={files}
+            input={input}
+            sessionId={chat.sessionId}
+            contextUsage={currentContextUsage}
+            sessionUsage={currentSessionUsage}
+            workspaces={workspaces}
+            workspaceId={currentWorkspaceId}
+            workspaceValid={currentWorkspaceValid}
+            sandboxMode={currentSandboxMode}
+            sandboxUpdating={sandboxRequest?.sessionId === chat.sessionId}
+            workspaceLocked={Boolean(chat.sessionId && (
+              (currentSessionSummary?.message_count ?? 0) > 0 || chat.messages.length > 0
+            ))}
+            compacting={currentTurn.status === "compacting"
+              || (compactionNotice.sessionId === chat.sessionId && compactionNotice.visible)}
+            sending={sending}
+            onFiles={(next) => {
+              setFiles(next);
+              setFileDrafts((current) => ({ ...current, [routeKey(routeSession)]: next }));
+            }}
+            onInput={(value) => {
+              setInput(value);
+              setTextDrafts((current) => ({ ...current, [routeKey(routeSession)]: value }));
+            }}
+            onSend={() => void submit()}
+            onStop={stopTurn}
+            onWorkspaceChange={handleWorkspaceChange}
+            onSandboxModeChange={handleSandboxModeChange}
+          />
+        )}
       </main>
     </div>
   );
@@ -964,330 +1251,7 @@ function ConversationScrollButton({ hasTailWindow, onReturnToLatest }: {
   );
 }
 
-function SessionSidebar(props: {
-  sessions: SessionSummary[];
-  activeSessionId: string;
-  onCreate: () => void;
-  onDelete: (id: string) => Promise<void>;
-  onRename: (id: string, title: string) => Promise<void>;
-  onSelect: (id: string) => void;
-}) {
-  const groups = useMemo(() => groupSessionsByUpdatedAt(props.sessions), [props.sessions]);
-  const [menuSessionId, setMenuSessionId] = useState("");
-  const [editingSessionId, setEditingSessionId] = useState("");
-  const [titleDraft, setTitleDraft] = useState("");
-  const [deleteTarget, setDeleteTarget] = useState<SessionSummary | null>(null);
-  const [proactiveTarget, setProactiveTarget] = useState<SessionSummary | null>(null);
-  const [deleting, setDeleting] = useState(false);
-  const [scrollbarVisible, setScrollbarVisible] = useState(false);
-  const scrollbarHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const sessionListRef = useRef<HTMLElement>(null);
 
-  useEffect(() => {
-    // 新会话发送消息后出现在侧栏时，自动滚动定位到该会话
-    if (sessionListRef.current) {
-      const activeRow = sessionListRef.current.querySelector(".session-row.active");
-      if (activeRow && typeof activeRow.scrollIntoView === "function") {
-        try {
-          activeRow.scrollIntoView({ behavior: "smooth", block: "nearest" });
-        } catch {
-          // jsdom 环境可能不支持 scrollIntoView，忽略
-        }
-      }
-    }
-  }, [props.activeSessionId, props.sessions]);
-
-  useEffect(() => () => {
-    if (scrollbarHideTimerRef.current !== null) clearTimeout(scrollbarHideTimerRef.current);
-  }, []);
-
-  const showSessionScrollbar = () => {
-    if (scrollbarHideTimerRef.current !== null) {
-      clearTimeout(scrollbarHideTimerRef.current);
-      scrollbarHideTimerRef.current = null;
-    }
-    setScrollbarVisible(true);
-  };
-
-  const scheduleSessionScrollbarHide = () => {
-    if (scrollbarHideTimerRef.current !== null) clearTimeout(scrollbarHideTimerRef.current);
-    // 移出后保留短暂视觉提示，避免用户刚离开列表时滚动位置突然失去参照。
-    scrollbarHideTimerRef.current = setTimeout(() => {
-      setScrollbarVisible(false);
-      scrollbarHideTimerRef.current = null;
-    }, 3_000);
-  };
-
-  useEffect(() => {
-    if (!menuSessionId) return;
-    const closeMenuOutside = (event: PointerEvent) => {
-      const owner = event.target instanceof Element
-        ? event.target.closest<HTMLElement>("[data-session-menu-owner]")
-        : null;
-      if (owner?.dataset.sessionMenuOwner !== menuSessionId) setMenuSessionId("");
-    };
-    // 使用捕获阶段，保证点击会话切换等控件时先收起菜单，再执行目标控件自己的动作。
-    document.addEventListener("pointerdown", closeMenuOutside, true);
-    return () => document.removeEventListener("pointerdown", closeMenuOutside, true);
-  }, [menuSessionId]);
-
-  const beginRename = (session: SessionSummary) => {
-    setMenuSessionId("");
-    setEditingSessionId(session.key);
-    setTitleDraft(session.title || session.first_message_content || "未命名会话");
-  };
-
-  const commitRename = async (session: SessionSummary) => {
-    const title = titleDraft.trim();
-    const original = session.title || session.first_message_content || "未命名会话";
-    if (!title || title === original) {
-      setEditingSessionId("");
-      return;
-    }
-    setEditingSessionId("");
-    await props.onRename(session.key, title).catch(() => setEditingSessionId(session.key));
-  };
-
-  return (
-    <div className="session-panel">
-      <div className="brand-lockup">
-        <span className="brand-mark">B</span>
-        <strong>BeanAgent</strong>
-      </div>
-      <button className="new-chat-button" onClick={props.onCreate}><MessageSquarePlus size={17} />新建会话</button>
-      <nav
-        ref={sessionListRef}
-        className={`session-list ${scrollbarVisible ? "scrollbar-visible" : ""}`}
-        aria-label="会话列表"
-        onPointerEnter={showSessionScrollbar}
-        onPointerLeave={scheduleSessionScrollbarHide}
-      >
-        {props.sessions.length === 0 ? <p className="session-empty">完成第一轮对话后，会话会出现在这里。</p> : groups.map((group) => (
-          <section className="session-group" key={group.label}>
-            <h2 className="session-group-title">{group.label}</h2>
-            {group.sessions.map((session) => {
-              const title = session.title || session.first_message_content || "未命名会话";
-              const active = session.key === props.activeSessionId;
-              return (
-                <div
-                  key={session.key}
-                  className={`session-row ${active ? "active" : ""}`}
-                  data-session-menu-owner={session.key}
-                >
-                  {editingSessionId === session.key ? (
-                    <input
-                      className="session-title-input"
-                      aria-label="会话标题"
-                      autoFocus
-                      maxLength={60}
-                      value={titleDraft}
-                      onBlur={() => void commitRename(session)}
-                      onChange={(event) => setTitleDraft(event.target.value)}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter") void commitRename(session);
-                        if (event.key === "Escape") setEditingSessionId("");
-                      }}
-                    />
-                  ) : (
-                    <button className="session-row-select" onClick={() => props.onSelect(session.key)}>
-                      <span>{title}</span>
-                    </button>
-                  )}
-                  <button
-                    className="session-menu-trigger"
-                    aria-label={`打开会话“${title}”的菜单`}
-                    aria-expanded={menuSessionId === session.key}
-                    onClick={() => setMenuSessionId((current) => current === session.key ? "" : session.key)}
-                  >
-                    <MoreHorizontal size={17} />
-                  </button>
-                  {menuSessionId === session.key ? (
-                    <div className="session-menu" role="menu">
-                      <button role="menuitem" onClick={() => { setMenuSessionId(""); setProactiveTarget(session); }}><Bell size={15} />主动设置</button>
-                      <button role="menuitem" onClick={() => beginRename(session)}><Pencil size={15} />重命名</button>
-                      <button className="danger" role="menuitem" onClick={() => { setMenuSessionId(""); setDeleteTarget(session); }}><Trash2 size={15} />删除</button>
-                    </div>
-                  ) : null}
-                </div>
-              );
-            })}
-          </section>
-        ))}
-      </nav>
-      <Dialog.Root open={deleteTarget !== null} onOpenChange={(open) => { if (!open && !deleting) setDeleteTarget(null); }}>
-        <Dialog.Portal>
-          <Dialog.Overlay className="dialog-overlay" onClick={() => { if (!deleting) setDeleteTarget(null); }} />
-          <Dialog.Content className="delete-session-dialog">
-            <Dialog.Title>删除“{deleteTarget ? (deleteTarget.title || deleteTarget.first_message_content || "未命名会话") : ""}”？</Dialog.Title>
-            <Dialog.Description>
-              该会话中的消息和工具执行记录将被永久删除。<br />
-              已沉淀的长期记忆不会随会话删除。<br />
-              此操作无法撤销。
-            </Dialog.Description>
-            <div className="delete-dialog-actions">
-              <Dialog.Close asChild><button disabled={deleting}>取消</button></Dialog.Close>
-              <button
-                className="confirm-delete"
-                disabled={deleting}
-                onClick={() => {
-                  if (!deleteTarget) return;
-                  setDeleting(true);
-                  void props.onDelete(deleteTarget.key)
-                    .then(() => setDeleteTarget(null))
-                    .catch(() => undefined)
-                    .finally(() => setDeleting(false));
-                }}
-              >确认删除</button>
-            </div>
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
-      <ProactiveSettingsDialog target={proactiveTarget} onClose={() => setProactiveTarget(null)} />
-    </div>
-  );
-}
-
-function ProactiveSettingsDialog({ target, onClose }: { target: SessionSummary | null; onClose: () => void }) {
-  const [settings, setSettings] = useState<ProactiveSettings | null>(null);
-  const [reminders, setReminders] = useState<ScheduledReminder[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState("");
-  const [help, setHelp] = useState("");
-  const [confirmReminderId, setConfirmReminderId] = useState("");
-  const [deletingReminderId, setDeletingReminderId] = useState("");
-
-  useEffect(() => {
-    if (!target) return;
-    setLoading(true);
-    setError("");
-    setConfirmReminderId("");
-    setDeletingReminderId("");
-    Promise.all([fetchProactiveSettings(target.key), fetchReminders(target.key)])
-      .then(([nextSettings, nextReminders]) => { setSettings(nextSettings); setReminders(nextReminders); })
-      .catch((reason) => setError(reason instanceof Error ? reason.message : "加载失败"))
-      .finally(() => setLoading(false));
-  }, [target]);
-
-  useEffect(() => {
-    if (!help) return;
-    const close = () => setHelp("");
-    document.addEventListener("pointerdown", close);
-    return () => document.removeEventListener("pointerdown", close);
-  }, [help]);
-
-  const update = <K extends keyof ProactiveSettings>(key: K, value: ProactiveSettings[K]) => {
-    setSettings((current) => current ? { ...current, [key]: value } : current);
-  };
-  const save = async () => {
-    if (!target || !settings) return;
-    setSaving(true);
-    setError("");
-    try {
-      setSettings(await saveProactiveSettings(target.key, settings));
-      onClose();
-    } catch (reason) {
-      setError(reason instanceof Error ? reason.message : "保存失败");
-    } finally {
-      setSaving(false);
-    }
-  };
-  const refreshReminderList = async () => {
-    if (target) setReminders(await fetchReminders(target.key));
-  };
-  const removeReminder = async (item: ScheduledReminder) => {
-    if (!target || deletingReminderId) return;
-    setDeletingReminderId(item.id);
-    setError("");
-    try {
-      await deleteReminder(target.key, item.id);
-      setConfirmReminderId("");
-      await refreshReminderList();
-    } catch (reason) {
-      setError(reason instanceof Error ? reason.message : String(reason));
-    } finally {
-      setDeletingReminderId("");
-    }
-  };
-
-  return (
-    <Dialog.Root open={target !== null} onOpenChange={(open) => { if (!open && !saving) onClose(); }}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="dialog-overlay" />
-        <Dialog.Content className="proactive-dialog">
-          <header className="proactive-dialog-header">
-            <div><Dialog.Title>主动设置</Dialog.Title><Dialog.Description>{target?.title || target?.first_message_content || "当前会话"}</Dialog.Description></div>
-            <Dialog.Close asChild><button className="icon-button" aria-label="关闭"><X size={17} /></button></Dialog.Close>
-          </header>
-          {loading || !settings ? <div className="proactive-loading">{error || "正在加载…"}</div> : (
-            <div className="proactive-dialog-body">
-              <SettingsSection title="提醒" enabled={settings.reminders_enabled} onEnabled={(value) => update("reminders_enabled", value)}>
-                <SettingRow label="勿扰时段处理" helpId="reminder-policy" help={help} onHelp={setHelp} helpText="延后：勿扰结束后发送；照常发送：仍按原时间；跳过：本次不发送。">
-                  <select value={settings.reminder_quiet_policy} onChange={(event) => update("reminder_quiet_policy", event.target.value as ProactiveSettings["reminder_quiet_policy"])}>
-                    <option value="delay">延后发送</option><option value="send">照常发送</option><option value="skip">跳过本次</option>
-                  </select>
-                </SettingRow>
-                <div className="reminder-list">
-                  <div className="reminder-list-title"><span>已创建的提醒</span><small>通过对话创建</small></div>
-                  {reminders.length === 0 ? <p className="reminder-empty">暂无提醒</p> : reminders.map((item) => (
-                    <div className={`reminder-item${confirmReminderId === item.id ? " confirming" : ""}`} key={item.id}>
-                      <div><strong>{item.name || (item.tier === "instant" ? "固定提醒" : "AI 定时任务")}</strong><small>{item.trigger === "every" ? "周期 · " : ""}{new Date(item.fire_at).toLocaleString()} · {item.tier === "instant" ? "固定文本" : "到期执行 prompt"}{item.status === "failed" ? ` · 失败：${item.last_error}` : ""}</small></div>
-                      {confirmReminderId === item.id ? (
-                        <span className="reminder-confirm-actions">
-                          <button type="button" disabled={deletingReminderId === item.id} onClick={() => setConfirmReminderId("")}>取消</button>
-                          <button type="button" className="confirm-delete" disabled={deletingReminderId === item.id} onClick={() => void removeReminder(item)}>{deletingReminderId === item.id ? "删除中" : "确认删除"}</button>
-                        </span>
-                      ) : (
-                        <button className="icon-button danger" aria-label="删除提醒" onClick={() => setConfirmReminderId(item.id)}><Trash2 size={15} /></button>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </SettingsSection>
-
-              <SettingsSection title="主动聊天" enabled={settings.conversation_enabled} onEnabled={(value) => update("conversation_enabled", value)}>
-                <SettingRow label="主动程度" helpId="activity" help={help} onHelp={setHelp} helpText="算法倾向：克制更少尝试，均衡适合日常，积极更愿意延续明确未完成的话题；所有档位仍受间隔、次数和勿扰限制。">
-                  <select value={settings.activity_level} onChange={(event) => update("activity_level", event.target.value as ProactiveSettings["activity_level"])}>
-                    <option value="restrained">克制</option><option value="balanced">均衡</option><option value="active">积极</option>
-                  </select>
-                </SettingRow>
-                <SettingRow label="最短间隔" helpId="interval" help={help} onHelp={setHelp} helpText="一次主动聊天后，至少等待这么久再尝试。这是明确的频率边界，主动程度不会越过它。">
-                  <NumberSetting value={settings.min_conversation_interval_hours} min={1} max={168} suffix="小时" onChange={(value) => update("min_conversation_interval_hours", value)} />
-                </SettingRow>
-                <SettingRow label="每日最多" helpId="daily" help={help} onHelp={setHelp} helpText="当天最多主动聊天的次数，可输入 1 到 20。普通问题的正常回答不计入。">
-                  <NumberSetting value={settings.daily_conversation_limit} min={1} max={20} suffix="次" onChange={(value) => update("daily_conversation_limit", value)} />
-                </SettingRow>
-              </SettingsSection>
-
-              <section className="settings-section quiet-section">
-                <div className="settings-section-title"><div><strong>勿扰时间</strong><span>提醒和主动聊天共用</span></div><Toggle checked={settings.quiet_hours_enabled} onChange={(value) => update("quiet_hours_enabled", value)} /></div>
-                <div className="quiet-time-row"><input type="time" value={settings.quiet_start} onChange={(event) => update("quiet_start", event.target.value)} /><span>至</span><input type="time" value={settings.quiet_end} onChange={(event) => update("quiet_end", event.target.value)} /></div>
-              </section>
-              {error ? <div className="settings-error" role="alert">{error}</div> : null}
-            </div>
-          )}
-          <footer className="proactive-dialog-footer"><Dialog.Close asChild><button className="secondary-action" disabled={saving}>取消</button></Dialog.Close><button className="primary-action" disabled={saving || loading || !settings} onClick={() => void save()}>{saving ? "保存中…" : "保存设置"}</button></footer>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
-  );
-}
-
-function SettingsSection({ title, enabled, onEnabled, children }: { title: string; enabled: boolean; onEnabled: (value: boolean) => void; children: ReactNode }) {
-  return <section className={`settings-section${enabled ? "" : " disabled"}`}><div className="settings-section-title"><strong>{title}</strong><Toggle checked={enabled} onChange={onEnabled} /></div><div className="settings-section-content">{children}</div></section>;
-}
-
-function SettingRow({ label, helpId, help, onHelp, helpText, children }: { label: string; helpId: string; help: string; onHelp: (id: string) => void; helpText: string; children: ReactNode }) {
-  return <div className="setting-row"><div className="setting-label"><span>{label}</span><span className="help-owner" onPointerDown={(event) => event.stopPropagation()}><button className="help-button" aria-label={`说明：${label}`} onClick={() => onHelp(help === helpId ? "" : helpId)}><AlertCircle size={13} /></button>{help === helpId ? <span className="help-popover">{helpText}</span> : null}</span></div>{children}</div>;
-}
-
-function Toggle({ checked, onChange }: { checked: boolean; onChange: (value: boolean) => void }) {
-  return <button type="button" className={`toggle${checked ? " on" : ""}`} role="switch" aria-checked={checked} onClick={() => onChange(!checked)}><span /></button>;
-}
-
-function NumberSetting({ value, min, max, suffix, onChange }: { value: number; min: number; max: number; suffix: string; onChange: (value: number) => void }) {
-  return <label className="number-setting"><input type="number" min={min} max={max} value={value} onChange={(event) => onChange(Math.max(min, Math.min(max, Number(event.target.value) || min)))} /><span>{suffix}</span></label>;
-}
 
 function ConnectionControl({ status, onReconnect }: { status: ConnectionStatus; onReconnect: () => void }) {
   const label = { connecting: "连接中", connected: "已连接", reconnecting: "重连中", offline: "已断开" }[status];
@@ -1573,7 +1537,8 @@ function AttachmentGallery({ paths }: { paths: string[] }) {
 
 function Composer(props: {
   input: string; files: File[]; active: boolean; turnStatus: "idle" | "submitting" | "queued" | "running" | "compacting"; compacting: boolean; queuePosition: number | null; connected: boolean; sending: boolean; sessionId: string; contextUsage?: ContextUsage; sessionUsage?: SessionUsage;
-  onInput: (value: string) => void; onFiles: (files: File[]) => void; onSend: () => void; onStop: () => void;
+  workspaces: Workspace[]; workspaceId: string | null; workspaceValid: boolean; sandboxMode: SandboxMode; sandboxUpdating: boolean; workspaceLocked: boolean;
+  onInput: (value: string) => void; onFiles: (files: File[]) => void; onSend: () => void; onStop: () => void; onWorkspaceChange: (workspaceId: string | null) => void; onSandboxModeChange: (mode: SandboxMode, riskConfirmed?: boolean) => void;
 }) {
   const [attachmentError, setAttachmentError] = useState("");
   const [dragging, setDragging] = useState(false);
@@ -1804,6 +1769,7 @@ function Composer(props: {
     props.onStop();
   }, [props.onStop]);
   const speechRunning = listening || speechActiveRef.current;
+  const sandboxControlsLocked = !props.connected || props.active || props.sending || props.sandboxUpdating;
 
   return (
     <>
@@ -1853,6 +1819,19 @@ function Composer(props: {
         ) : null}
         <div className="composer-actions">
           <ContextUsageIndicator usage={props.contextUsage} compacting={props.compacting} />
+          <WorkspaceSelector
+            workspaces={props.workspaces}
+            value={props.workspaceId}
+            valid={props.workspaceValid}
+            disabled={sandboxControlsLocked || props.workspaceLocked}
+            onChange={props.onWorkspaceChange}
+          />
+          <PermissionSelector
+            value={props.sandboxMode}
+            hasWorkspace={props.workspaceId !== null}
+            disabled={sandboxControlsLocked}
+            onChange={props.onSandboxModeChange}
+          />
           <label className="icon-button composer-tool-button attach-button" title="添加文本或图片">
             <Paperclip size={18} /><span className="sr-only">添加附件</span>
             <input type="file" multiple accept={ATTACHMENT_ACCEPT} onChange={(event) => { addFiles(Array.from(event.target.files ?? [])); event.target.value = ""; }} />

--- a/frontend/chat/src/App.tsx
+++ b/frontend/chat/src/App.tsx
@@ -33,7 +33,7 @@ import { Streamdown } from "streamdown";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import type { StickToBottomContext } from "use-stick-to-bottom";
 
-import { deleteSession, deleteWorkspace, fetchMessagePage, fetchMessagesAroundPage, fetchNotifications, fetchOlderMessages, fetchSessions, fetchTurns, fetchWorkspaces, mediaUrl, registerWorkspace, renameSession, uploadAttachment } from "./api";
+import { deleteSession, deleteWorkspace, fetchMessagePage, fetchMessagesAroundPage, fetchNotifications, fetchOlderMessages, fetchSessions, fetchTurns, fetchWorkspaces, mediaUrl, openWorkspaceDirectory, registerWorkspace, renameSession, setSessionPinned, updateWorkspace, uploadAttachment } from "./api";
 import { idleTurnState, initialChatState, notificationRowsToMessages, reduceChatFrame, rowsToMessages } from "./chatReducer";
 import { composeTimeline, reconcileMessages } from "./timeline";
 import { parseMemoryCitations } from "./citations";
@@ -451,6 +451,7 @@ export function App() {
             title: "新对话",
             created_at: createdAt,
             updated_at: createdAt,
+            last_activity_at: createdAt,
             message_count: 0,
             first_message_content: "",
             workspace_id: newSessionConfigRef.current.workspaceId,
@@ -468,7 +469,7 @@ export function App() {
       const acknowledgedAt = new Date().toISOString();
       setSessions((current) => current.map((session) => (
         session.key === frame.session_id
-          ? { ...session, updated_at: acknowledgedAt }
+          ? { ...session, updated_at: acknowledgedAt, last_activity_at: acknowledgedAt }
           : session
       )));
     }
@@ -657,6 +658,44 @@ export function App() {
         setNewSessionWorkspaceId(null);
         if (newSessionMode === "workspace-write") setNewSessionMode("read-only");
       }
+    } catch (error) {
+      dispatch(errorFrame(error));
+      throw error;
+    }
+  };
+
+  const handleUpdateWorkspace = async (workspaceId: string, patch: { title?: string; pinned?: boolean }) => {
+    try {
+      const updated = await updateWorkspace(workspaceId, patch);
+      setWorkspaces((current) => current.map((workspace) => (
+        workspace.id === workspaceId ? updated : workspace
+      )));
+      if (Object.hasOwn(patch, "title")) {
+        setSessions((current) => current.map((session) => (
+          session.workspace_id === workspaceId
+            ? { ...session, workspace_title: updated.title }
+            : session
+        )));
+      }
+    } catch (error) {
+      dispatch(errorFrame(error));
+      throw error;
+    }
+  };
+
+  const handleOpenWorkspace = async (workspaceId: string) => {
+    try {
+      await openWorkspaceDirectory(workspaceId);
+    } catch (error) {
+      dispatch(errorFrame(error));
+      throw error;
+    }
+  };
+
+  const handleSetSessionPinned = async (sessionId: string, pinned: boolean) => {
+    try {
+      await setSessionPinned(sessionId, pinned);
+      await refreshSessions();
     } catch (error) {
       dispatch(errorFrame(error));
       throw error;
@@ -983,6 +1022,7 @@ export function App() {
             title: "新对话",
             created_at: submittedAt,
             updated_at: submittedAt,
+            last_activity_at: submittedAt,
             message_count: 0,
             first_message_content: "",
           }, ...current]);
@@ -1026,8 +1066,11 @@ export function App() {
       onCreate={createSession}
       onDelete={handleDeleteSession}
       onDeleteWorkspace={handleDeleteWorkspace}
+      onOpenWorkspace={handleOpenWorkspace}
       onRegisterWorkspace={handleRegisterWorkspace}
       onRename={handleRenameSession}
+      onSetSessionPinned={handleSetSessionPinned}
+      onUpdateWorkspace={handleUpdateWorkspace}
       onSelect={selectSession}
     />
   );

--- a/frontend/chat/src/SandboxControls.tsx
+++ b/frontend/chat/src/SandboxControls.tsx
@@ -1,0 +1,259 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { Check, ChevronDown, Folder, Shield, ShieldAlert } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+
+import type { ApprovalRequest, SandboxMode, Workspace } from "./types";
+
+type ComposerMenuOption = {
+  id: string;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+  icon: ReactNode;
+};
+
+function ComposerMenu(props: {
+  label: string;
+  value: string;
+  options: ComposerMenuOption[];
+  disabled: boolean;
+  onChange: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const selected = props.options.find((option) => option.id === props.value) ?? props.options[0];
+
+  useEffect(() => {
+    if (props.disabled) setOpen(false);
+  }, [props.disabled]);
+  useEffect(() => {
+    if (!open) return undefined;
+    const close = (event: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", close);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", close);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
+
+  return (
+    <div className="composer-select" ref={rootRef}>
+      <button
+        type="button"
+        className="composer-select-trigger"
+        aria-label={`${props.label}：${selected.label}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        disabled={props.disabled}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span className="composer-select-icon" aria-hidden="true">{selected.icon}</span>
+        <span className="composer-select-label">{selected.label}</span>
+        <ChevronDown size={14} className={open ? "open" : ""} aria-hidden="true" />
+      </button>
+      {open ? (
+        <div className="composer-select-menu" role="menu" aria-label={props.label}>
+          {props.options.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              role="menuitemradio"
+              aria-checked={option.id === props.value}
+              disabled={option.disabled}
+              title={option.disabled ? option.description : undefined}
+              onClick={() => {
+                setOpen(false);
+                if (option.id !== props.value) props.onChange(option.id);
+              }}
+            >
+              <span className="composer-option-icon" aria-hidden="true">{option.icon}</span>
+              <span className="composer-option-copy">
+                <strong>{option.label}</strong>
+                {option.description ? <small>{option.description}</small> : null}
+              </span>
+              {option.id === props.value ? <Check size={15} aria-hidden="true" /> : null}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function WorkspaceSelector(props: {
+  workspaces: Workspace[];
+  value: string | null;
+  valid: boolean;
+  disabled: boolean;
+  onChange: (workspaceId: string | null) => void;
+}) {
+  const options: ComposerMenuOption[] = [{
+    id: "none",
+    label: "无工作目录",
+    description: "使用会话私有临时目录",
+    icon: <Folder size={15} />,
+  }, ...props.workspaces.map((workspace) => ({
+    id: workspace.id,
+    label: workspace.title || workspaceName(workspace.canonical_path),
+    description: workspace.valid ? workspace.canonical_path : "目录不可用",
+    disabled: !workspace.valid,
+    icon: <Folder size={15} />,
+  }))];
+  if (props.value && !options.some((option) => option.id === props.value)) {
+    options.push({
+      id: props.value,
+      label: "目录不可用",
+      description: "原工作目录未注册或已移除",
+      disabled: true,
+      icon: <Folder size={15} />,
+    });
+  }
+  if (props.value && !props.valid) {
+    const current = options.find((option) => option.id === props.value);
+    if (current) current.disabled = true;
+  }
+  return (
+    <ComposerMenu
+      label="工作目录"
+      value={props.value ?? "none"}
+      options={options}
+      disabled={props.disabled}
+      onChange={(id) => props.onChange(id === "none" ? null : id)}
+    />
+  );
+}
+
+export function PermissionSelector(props: {
+  value: SandboxMode;
+  hasWorkspace: boolean;
+  disabled: boolean;
+  onChange: (mode: SandboxMode, riskConfirmed?: boolean) => void;
+}) {
+  const [confirmationOpen, setConfirmationOpen] = useState(false);
+  const [acknowledged, setAcknowledged] = useState(false);
+  const options: ComposerMenuOption[] = [
+    { id: "read-only", label: "只读", description: "禁止文件写入，可申请单次授权", icon: <Shield size={15} /> },
+    { id: "workspace-write", label: "工作区可写", description: props.hasWorkspace ? "仅允许写入当前工作目录" : "请先选择工作目录", disabled: !props.hasWorkspace, icon: <Shield size={15} /> },
+    { id: "danger-full-access", label: "完全访问", description: "使用当前 Windows 用户原有权限", icon: <ShieldAlert size={15} /> },
+  ];
+  const closeConfirmation = () => {
+    setAcknowledged(false);
+    setConfirmationOpen(false);
+  };
+  return (
+    <>
+      <ComposerMenu
+        label="权限"
+        value={props.value}
+        options={options}
+        disabled={props.disabled}
+        onChange={(id) => {
+          const mode = id as SandboxMode;
+          if (mode === "danger-full-access") {
+            setAcknowledged(false);
+            setConfirmationOpen(true);
+          } else {
+            props.onChange(mode);
+          }
+        }}
+      />
+      <Dialog.Root open={confirmationOpen} onOpenChange={(open) => { if (!open) closeConfirmation(); }}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="dialog-overlay" />
+          <Dialog.Content className="risk-dialog">
+            <span className="risk-dialog-icon" aria-hidden="true"><ShieldAlert size={22} /></span>
+            <Dialog.Title>启用完全访问？</Dialog.Title>
+            <Dialog.Description>命令和文件操作将绕过 BeanAgent 的本地写入限制，并使用当前 Windows 用户原有权限。</Dialog.Description>
+            <label className="risk-acknowledgement">
+              <input type="checkbox" checked={acknowledged} onChange={(event) => setAcknowledged(event.target.checked)} />
+              <span>我了解该会话可能修改或删除工作目录外的文件</span>
+            </label>
+            <div className="risk-dialog-actions">
+              <button type="button" className="secondary-action" onClick={closeConfirmation}>取消</button>
+              <button
+                type="button"
+                className="danger-action"
+                disabled={!acknowledged || props.disabled}
+                onClick={() => {
+                  if (!acknowledged || props.disabled) return;
+                  closeConfirmation();
+                  props.onChange("danger-full-access", true);
+                }}
+              >启用完全访问</button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
+  );
+}
+
+export function ApprovalPanel(props: {
+  approval: ApprovalRequest;
+  submitting: boolean;
+  onDecide: (decision: "allowed-once" | "rejected") => void;
+}) {
+  const entries = Object.entries(props.approval.arguments);
+  return (
+    <footer className="composer-wrap approval-wrap">
+      <section className="approval-panel" aria-label="待处理权限审批">
+        <div className="approval-strip"><span aria-hidden="true" />等待授权</div>
+        <div className="approval-body" tabIndex={0} role="group" aria-label="越权操作详情">
+          <strong>{props.approval.reason || `${props.approval.tool_name} 请求临时提高权限`}</strong>
+          <span className="approval-operation">{props.approval.operation}</span>
+          {entries.length ? (
+            <dl className="approval-arguments">
+              {entries.map(([key, value]) => (
+                <div key={key}><dt>{approvalArgumentLabel(key)}</dt><dd>{displayApprovalArgument(value)}</dd></div>
+              ))}
+            </dl>
+          ) : null}
+        </div>
+        <div className="approval-actions">
+          <button className="secondary-action approval-reject" disabled={props.submitting} onClick={() => props.onDecide("rejected")}>拒绝</button>
+          <button className="primary-action" disabled={props.submitting} onClick={() => props.onDecide("allowed-once")}>{props.submitting ? "提交中…" : "仅允许本次"}</button>
+        </div>
+      </section>
+    </footer>
+  );
+}
+
+function workspaceName(path: string): string {
+  const normalized = path.replace(/[\\/]+$/, "");
+  return normalized.split(/[\\/]/).pop() || path || "工作目录";
+}
+
+function approvalArgumentLabel(key: string): string {
+  const labels: Record<string, string> = {
+    command: "完整命令",
+    path: "目标路径",
+    source: "源路径",
+    destination: "目标路径",
+    cwd: "执行目录",
+    description: "命令说明",
+    timeout: "超时秒数",
+    content_length: "写入字符数",
+    old_text_length: "原文本字符数",
+    new_text_length: "新文本字符数",
+    replace_all: "替换全部匹配",
+  };
+  return labels[key] ?? key;
+}
+
+function displayApprovalArgument(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "boolean") return value ? "是" : "否";
+  if (value === null || value === undefined) return "-";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/frontend/chat/src/SessionSidebar.tsx
+++ b/frontend/chat/src/SessionSidebar.tsx
@@ -1,0 +1,501 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import {
+  AlertCircle,
+  Bell,
+  Folder,
+  FolderPlus,
+  MessageSquarePlus,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+  Unlink,
+  X,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+
+import {
+  deleteReminder,
+  fetchProactiveSettings,
+  fetchReminders,
+  saveProactiveSettings,
+} from "./api";
+import { groupSessionsByUpdatedAt } from "./sessionGroups";
+import type {
+  ProactiveSettings,
+  ScheduledReminder,
+  SessionSummary,
+  Workspace,
+} from "./types";
+
+export function SessionSidebar(props: {
+  sessions: SessionSummary[];
+  workspaces: Workspace[];
+  activeSessionId: string;
+  onCreate: (workspaceId?: string | null) => void;
+  onDelete: (id: string) => Promise<void>;
+  onDeleteWorkspace: (id: string) => Promise<void>;
+  onRegisterWorkspace: (path: string, title: string) => Promise<Workspace>;
+  onRename: (id: string, title: string) => Promise<void>;
+  onSelect: (id: string) => void;
+}) {
+  const [menuSessionId, setMenuSessionId] = useState("");
+  const [editingSessionId, setEditingSessionId] = useState("");
+  const [titleDraft, setTitleDraft] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<SessionSummary | null>(null);
+  const [deleteWorkspaceTarget, setDeleteWorkspaceTarget] = useState<Workspace | null>(null);
+  const [workspaceDialogOpen, setWorkspaceDialogOpen] = useState(false);
+  const [workspacePath, setWorkspacePath] = useState("");
+  const [workspaceTitle, setWorkspaceTitle] = useState("");
+  const [workspaceError, setWorkspaceError] = useState("");
+  const [proactiveTarget, setProactiveTarget] = useState<SessionSummary | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deletingWorkspace, setDeletingWorkspace] = useState(false);
+  const [registeringWorkspace, setRegisteringWorkspace] = useState(false);
+  const [scrollbarVisible, setScrollbarVisible] = useState(false);
+  const scrollbarHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sessionListRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    // 新会话发送消息后出现在侧栏时，自动滚动定位到该会话。
+    const activeRow = sessionListRef.current?.querySelector(".session-row.active");
+    if (activeRow && typeof activeRow.scrollIntoView === "function") {
+      try {
+        activeRow.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      } catch {
+        // jsdom 环境可能不支持 scrollIntoView。
+      }
+    }
+  }, [props.activeSessionId, props.sessions]);
+
+  useEffect(() => () => {
+    if (scrollbarHideTimerRef.current !== null) clearTimeout(scrollbarHideTimerRef.current);
+  }, []);
+
+  const showSessionScrollbar = () => {
+    if (scrollbarHideTimerRef.current !== null) {
+      clearTimeout(scrollbarHideTimerRef.current);
+      scrollbarHideTimerRef.current = null;
+    }
+    setScrollbarVisible(true);
+  };
+
+  const scheduleSessionScrollbarHide = () => {
+    if (scrollbarHideTimerRef.current !== null) clearTimeout(scrollbarHideTimerRef.current);
+    // 移出后保留短暂视觉提示，避免滚动位置突然失去参照。
+    scrollbarHideTimerRef.current = setTimeout(() => {
+      setScrollbarVisible(false);
+      scrollbarHideTimerRef.current = null;
+    }, 3_000);
+  };
+
+  useEffect(() => {
+    if (!menuSessionId) return;
+    const closeMenuOutside = (event: PointerEvent) => {
+      const owner = event.target instanceof Element
+        ? event.target.closest<HTMLElement>("[data-session-menu-owner]")
+        : null;
+      if (owner?.dataset.sessionMenuOwner !== menuSessionId) setMenuSessionId("");
+    };
+    // 捕获阶段先收起菜单，再执行目标控件自己的动作。
+    document.addEventListener("pointerdown", closeMenuOutside, true);
+    return () => document.removeEventListener("pointerdown", closeMenuOutside, true);
+  }, [menuSessionId]);
+
+  const beginRename = (session: SessionSummary) => {
+    setMenuSessionId("");
+    setEditingSessionId(session.key);
+    setTitleDraft(session.title || session.first_message_content || "未命名会话");
+  };
+
+  const commitRename = async (session: SessionSummary) => {
+    const title = titleDraft.trim();
+    const original = session.title || session.first_message_content || "未命名会话";
+    if (!title || title === original) {
+      setEditingSessionId("");
+      return;
+    }
+    setEditingSessionId("");
+    await props.onRename(session.key, title).catch(() => setEditingSessionId(session.key));
+  };
+
+  const renderSessionRows = (sessions: SessionSummary[]) => sessions.map((session) => {
+    const title = session.title || session.first_message_content || "未命名会话";
+    const active = session.key === props.activeSessionId;
+    return (
+      <div
+        key={session.key}
+        className={`session-row ${active ? "active" : ""}`}
+        data-session-menu-owner={session.key}
+      >
+        {editingSessionId === session.key ? (
+          <input
+            className="session-title-input"
+            aria-label="会话标题"
+            autoFocus
+            maxLength={60}
+            value={titleDraft}
+            onBlur={() => void commitRename(session)}
+            onChange={(event) => setTitleDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") void commitRename(session);
+              if (event.key === "Escape") setEditingSessionId("");
+            }}
+          />
+        ) : (
+          <button className="session-row-select" onClick={() => props.onSelect(session.key)}>
+            <span>{title}</span>
+          </button>
+        )}
+        <button
+          className="session-menu-trigger"
+          aria-label={`打开会话“${title}”的菜单`}
+          aria-expanded={menuSessionId === session.key}
+          onClick={() => setMenuSessionId((current) => current === session.key ? "" : session.key)}
+        >
+          <MoreHorizontal size={17} />
+        </button>
+        {menuSessionId === session.key ? (
+          <div className="session-menu" role="menu">
+            <button role="menuitem" onClick={() => { setMenuSessionId(""); setProactiveTarget(session); }}><Bell size={15} />主动设置</button>
+            <button role="menuitem" onClick={() => beginRename(session)}><Pencil size={15} />重命名</button>
+            <button className="danger" role="menuitem" onClick={() => { setMenuSessionId(""); setDeleteTarget(session); }}><Trash2 size={15} />删除</button>
+          </div>
+        ) : null}
+      </div>
+    );
+  });
+
+  const renderSessions = (sessions: SessionSummary[]) => sessions.length ? groupSessionsByUpdatedAt(sessions).map((group) => (
+    <div className="session-group" key={group.label}>
+      <h3 className="session-group-title">{group.label}</h3>
+      {renderSessionRows(group.sessions)}
+    </div>
+  )) : <p className="workspace-session-empty">尚无会话</p>;
+
+  const submitWorkspace = async () => {
+    const path = workspacePath.trim();
+    if (!path || registeringWorkspace) return;
+    setRegisteringWorkspace(true);
+    setWorkspaceError("");
+    try {
+      await props.onRegisterWorkspace(path, workspaceTitle.trim());
+      setWorkspaceDialogOpen(false);
+      setWorkspacePath("");
+      setWorkspaceTitle("");
+    } catch (error) {
+      setWorkspaceError(error instanceof Error ? error.message : "无法添加工作目录");
+    } finally {
+      setRegisteringWorkspace(false);
+    }
+  };
+
+  const unassignedSessions = props.sessions.filter((session) => !session.workspace_id);
+  const registeredWorkspaceIds = new Set(props.workspaces.map((workspace) => workspace.id));
+  const unavailableByWorkspace = new Map<string, {
+    id: string;
+    title: string;
+    path: string;
+    sessions: SessionSummary[];
+  }>();
+  for (const session of props.sessions) {
+    const workspaceId = session.workspace_id;
+    if (!workspaceId || registeredWorkspaceIds.has(workspaceId)) continue;
+    const existing = unavailableByWorkspace.get(workspaceId);
+    if (existing) {
+      existing.sessions.push(session);
+      continue;
+    }
+    unavailableByWorkspace.set(workspaceId, {
+      id: workspaceId,
+      title: session.workspace_title || (
+        session.workspace_path ? workspaceName(session.workspace_path) : "不可用工作目录"
+      ),
+      path: session.workspace_path || "",
+      sessions: [session],
+    });
+  }
+  const unavailableWorkspaceGroups = [...unavailableByWorkspace.values()];
+
+  return (
+    <div className="session-panel">
+      <div className="brand-lockup">
+        <span className="brand-mark">B</span>
+        <strong>BeanAgent</strong>
+      </div>
+      <div className="sidebar-primary-actions">
+        <button className="new-chat-button" onClick={() => props.onCreate(null)}><MessageSquarePlus size={17} />新建会话</button>
+        <button className="add-workspace-button" onClick={() => { setWorkspaceError(""); setWorkspaceDialogOpen(true); }}><FolderPlus size={17} />添加工作目录</button>
+      </div>
+      <nav
+        ref={sessionListRef}
+        className={`session-list ${scrollbarVisible ? "scrollbar-visible" : ""}`}
+        aria-label="会话列表"
+        onPointerEnter={showSessionScrollbar}
+        onPointerLeave={scheduleSessionScrollbarHide}
+      >
+        <section className="workspace-group" data-workspace-id="none">
+          <header className="workspace-group-header">
+            <span className="workspace-group-icon"><Folder size={15} /></span>
+            <span className="workspace-group-copy"><strong>无工作目录</strong><small>会话私有临时目录</small></span>
+            <button className="workspace-header-action" aria-label="在无工作目录中新建会话" title="新建会话" onClick={() => props.onCreate(null)}><MessageSquarePlus size={15} /></button>
+          </header>
+          <div className="workspace-sessions">{renderSessions(unassignedSessions)}</div>
+        </section>
+        {props.workspaces.map((workspace) => (
+          <section className="workspace-group" key={workspace.id} data-workspace-id={workspace.id}>
+            <header className="workspace-group-header">
+              <span className={`workspace-group-icon${workspace.valid ? "" : " invalid"}`}><Folder size={15} /></span>
+              <span className="workspace-group-copy" title={workspace.canonical_path}>
+                <strong>{workspace.title || workspaceName(workspace.canonical_path)}</strong>
+                <small>{workspace.valid ? workspace.canonical_path : "目录不可用"}</small>
+              </span>
+              <button className="workspace-header-action" aria-label={`在“${workspace.title || workspaceName(workspace.canonical_path)}”中新建会话`} title="新建会话" disabled={!workspace.valid} onClick={() => props.onCreate(workspace.id)}><MessageSquarePlus size={15} /></button>
+              <button className="workspace-header-action" aria-label={`移除工作目录“${workspace.title || workspaceName(workspace.canonical_path)}”`} title="移除工作目录" onClick={() => setDeleteWorkspaceTarget(workspace)}><Unlink size={15} /></button>
+            </header>
+            <div className="workspace-sessions">{renderSessions(props.sessions.filter((session) => session.workspace_id === workspace.id))}</div>
+          </section>
+        ))}
+        {unavailableWorkspaceGroups.map((workspace) => (
+          <section className="workspace-group" key={`unavailable:${workspace.id}`} data-workspace-id={workspace.id}>
+            <header className="workspace-group-header">
+              <span className="workspace-group-icon invalid"><Folder size={15} /></span>
+              <span className="workspace-group-copy" title={workspace.path || undefined}>
+                <strong>{workspace.title}</strong>
+                <small>{workspace.path || "原工作目录未注册或加载失败"}</small>
+              </span>
+            </header>
+            <div className="workspace-sessions">{renderSessions(workspace.sessions)}</div>
+          </section>
+        ))}
+      </nav>
+      <Dialog.Root open={deleteTarget !== null} onOpenChange={(open) => { if (!open && !deleting) setDeleteTarget(null); }}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="dialog-overlay" onClick={() => { if (!deleting) setDeleteTarget(null); }} />
+          <Dialog.Content className="delete-session-dialog">
+            <Dialog.Title>删除“{deleteTarget ? (deleteTarget.title || deleteTarget.first_message_content || "未命名会话") : ""}”？</Dialog.Title>
+            <Dialog.Description>
+              该会话中的消息和工具执行记录将被永久删除。<br />
+              已沉淀的长期记忆不会随会话删除。<br />
+              此操作无法撤销。
+            </Dialog.Description>
+            <div className="delete-dialog-actions">
+              <Dialog.Close asChild><button disabled={deleting}>取消</button></Dialog.Close>
+              <button
+                className="confirm-delete"
+                disabled={deleting}
+                onClick={() => {
+                  if (!deleteTarget) return;
+                  setDeleting(true);
+                  void props.onDelete(deleteTarget.key)
+                    .then(() => setDeleteTarget(null))
+                    .catch(() => undefined)
+                    .finally(() => setDeleting(false));
+                }}
+              >确认删除</button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+      <Dialog.Root open={workspaceDialogOpen} onOpenChange={(open) => {
+        if (registeringWorkspace) return;
+        setWorkspaceDialogOpen(open);
+        if (!open) setWorkspaceError("");
+      }}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="dialog-overlay" />
+          <Dialog.Content className="workspace-dialog">
+            <div className="workspace-dialog-header">
+              <div><Dialog.Title>添加工作目录</Dialog.Title><Dialog.Description>注册本机已有目录，用于限定会话的可写范围。</Dialog.Description></div>
+              <Dialog.Close asChild><button className="icon-button" aria-label="关闭" disabled={registeringWorkspace}><X size={17} /></button></Dialog.Close>
+            </div>
+            <form onSubmit={(event) => { event.preventDefault(); void submitWorkspace(); }}>
+              <label>绝对路径<input autoFocus value={workspacePath} onChange={(event) => setWorkspacePath(event.target.value)} placeholder="D:\code\project" /></label>
+              <label>显示名称 <span>可选</span><input value={workspaceTitle} maxLength={80} onChange={(event) => setWorkspaceTitle(event.target.value)} placeholder="默认使用文件夹名称" /></label>
+              {workspaceError ? <p className="workspace-form-error" role="alert">{workspaceError}</p> : null}
+              <footer className="workspace-dialog-actions">
+                <Dialog.Close asChild><button type="button" className="secondary-action" disabled={registeringWorkspace}>取消</button></Dialog.Close>
+                <button type="submit" className="primary-action" disabled={registeringWorkspace || !workspacePath.trim()}>{registeringWorkspace ? "添加中…" : "添加"}</button>
+              </footer>
+            </form>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+      <Dialog.Root open={deleteWorkspaceTarget !== null} onOpenChange={(open) => { if (!open && !deletingWorkspace) setDeleteWorkspaceTarget(null); }}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="dialog-overlay" />
+          <Dialog.Content className="delete-session-dialog">
+            <Dialog.Title>移除“{deleteWorkspaceTarget ? (deleteWorkspaceTarget.title || workspaceName(deleteWorkspaceTarget.canonical_path)) : ""}”？</Dialog.Title>
+            <Dialog.Description>
+              只会移除 BeanAgent 中的注册和会话关联。<br />
+              磁盘上的目录和文件不会被删除，原有会话将归入无工作目录。
+            </Dialog.Description>
+            <div className="delete-dialog-actions">
+              <Dialog.Close asChild><button disabled={deletingWorkspace}>取消</button></Dialog.Close>
+              <button
+                className="confirm-delete"
+                disabled={deletingWorkspace}
+                onClick={() => {
+                  if (!deleteWorkspaceTarget) return;
+                  setDeletingWorkspace(true);
+                  void props.onDeleteWorkspace(deleteWorkspaceTarget.id)
+                    .then(() => setDeleteWorkspaceTarget(null))
+                    .catch(() => undefined)
+                    .finally(() => setDeletingWorkspace(false));
+                }}
+              >确认移除</button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+      <ProactiveSettingsDialog target={proactiveTarget} onClose={() => setProactiveTarget(null)} />
+    </div>
+  );
+}
+
+function ProactiveSettingsDialog({ target, onClose }: { target: SessionSummary | null; onClose: () => void }) {
+  const [settings, setSettings] = useState<ProactiveSettings | null>(null);
+  const [reminders, setReminders] = useState<ScheduledReminder[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [help, setHelp] = useState("");
+  const [confirmReminderId, setConfirmReminderId] = useState("");
+  const [deletingReminderId, setDeletingReminderId] = useState("");
+
+  useEffect(() => {
+    if (!target) return;
+    setLoading(true);
+    setError("");
+    setConfirmReminderId("");
+    setDeletingReminderId("");
+    Promise.all([fetchProactiveSettings(target.key), fetchReminders(target.key)])
+      .then(([nextSettings, nextReminders]) => { setSettings(nextSettings); setReminders(nextReminders); })
+      .catch((reason) => setError(reason instanceof Error ? reason.message : "加载失败"))
+      .finally(() => setLoading(false));
+  }, [target]);
+
+  useEffect(() => {
+    if (!help) return;
+    const close = () => setHelp("");
+    document.addEventListener("pointerdown", close);
+    return () => document.removeEventListener("pointerdown", close);
+  }, [help]);
+
+  const update = <K extends keyof ProactiveSettings>(key: K, value: ProactiveSettings[K]) => {
+    setSettings((current) => current ? { ...current, [key]: value } : current);
+  };
+  const save = async () => {
+    if (!target || !settings) return;
+    setSaving(true);
+    setError("");
+    try {
+      setSettings(await saveProactiveSettings(target.key, settings));
+      onClose();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "保存失败");
+    } finally {
+      setSaving(false);
+    }
+  };
+  const refreshReminderList = async () => {
+    if (target) setReminders(await fetchReminders(target.key));
+  };
+  const removeReminder = async (item: ScheduledReminder) => {
+    if (!target || deletingReminderId) return;
+    setDeletingReminderId(item.id);
+    setError("");
+    try {
+      await deleteReminder(target.key, item.id);
+      setConfirmReminderId("");
+      await refreshReminderList();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason));
+    } finally {
+      setDeletingReminderId("");
+    }
+  };
+
+  return (
+    <Dialog.Root open={target !== null} onOpenChange={(open) => { if (!open && !saving) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="dialog-overlay" />
+        <Dialog.Content className="proactive-dialog">
+          <header className="proactive-dialog-header">
+            <div><Dialog.Title>主动设置</Dialog.Title><Dialog.Description>{target?.title || target?.first_message_content || "当前会话"}</Dialog.Description></div>
+            <Dialog.Close asChild><button className="icon-button" aria-label="关闭"><X size={17} /></button></Dialog.Close>
+          </header>
+          {loading || !settings ? <div className="proactive-loading">{error || "正在加载…"}</div> : (
+            <div className="proactive-dialog-body">
+              <SettingsSection title="提醒" enabled={settings.reminders_enabled} onEnabled={(value) => update("reminders_enabled", value)}>
+                <SettingRow label="勿扰时段处理" helpId="reminder-policy" help={help} onHelp={setHelp} helpText="延后：勿扰结束后发送；照常发送：仍按原时间；跳过：本次不发送。">
+                  <select value={settings.reminder_quiet_policy} onChange={(event) => update("reminder_quiet_policy", event.target.value as ProactiveSettings["reminder_quiet_policy"])}>
+                    <option value="delay">延后发送</option><option value="send">照常发送</option><option value="skip">跳过本次</option>
+                  </select>
+                </SettingRow>
+                <div className="reminder-list">
+                  <div className="reminder-list-title"><span>已创建的提醒</span><small>通过对话创建</small></div>
+                  {reminders.length === 0 ? <p className="reminder-empty">暂无提醒</p> : reminders.map((item) => (
+                    <div className={`reminder-item${confirmReminderId === item.id ? " confirming" : ""}`} key={item.id}>
+                      <div><strong>{item.name || (item.tier === "instant" ? "固定提醒" : "AI 定时任务")}</strong><small>{item.trigger === "every" ? "周期 · " : ""}{new Date(item.fire_at).toLocaleString()} · {item.tier === "instant" ? "固定文本" : "到期执行 prompt"}{item.status === "failed" ? ` · 失败：${item.last_error}` : ""}</small></div>
+                      {confirmReminderId === item.id ? (
+                        <span className="reminder-confirm-actions">
+                          <button type="button" disabled={deletingReminderId === item.id} onClick={() => setConfirmReminderId("")}>取消</button>
+                          <button type="button" className="confirm-delete" disabled={deletingReminderId === item.id} onClick={() => void removeReminder(item)}>{deletingReminderId === item.id ? "删除中" : "确认删除"}</button>
+                        </span>
+                      ) : (
+                        <button className="icon-button danger" aria-label="删除提醒" onClick={() => setConfirmReminderId(item.id)}><Trash2 size={15} /></button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </SettingsSection>
+
+              <SettingsSection title="主动聊天" enabled={settings.conversation_enabled} onEnabled={(value) => update("conversation_enabled", value)}>
+                <SettingRow label="主动程度" helpId="activity" help={help} onHelp={setHelp} helpText="算法倾向：克制更少尝试，均衡适合日常，积极更愿意延续明确未完成的话题；所有档位仍受间隔、次数和勿扰限制。">
+                  <select value={settings.activity_level} onChange={(event) => update("activity_level", event.target.value as ProactiveSettings["activity_level"])}>
+                    <option value="restrained">克制</option><option value="balanced">均衡</option><option value="active">积极</option>
+                  </select>
+                </SettingRow>
+                <SettingRow label="最短间隔" helpId="interval" help={help} onHelp={setHelp} helpText="一次主动聊天后，至少等待这么久再尝试。这是明确的频率边界，主动程度不会越过它。">
+                  <NumberSetting value={settings.min_conversation_interval_hours} min={1} max={168} suffix="小时" onChange={(value) => update("min_conversation_interval_hours", value)} />
+                </SettingRow>
+                <SettingRow label="每日最多" helpId="daily" help={help} onHelp={setHelp} helpText="当天最多主动聊天的次数，可输入 1 到 20。普通问题的正常回答不计入。">
+                  <NumberSetting value={settings.daily_conversation_limit} min={1} max={20} suffix="次" onChange={(value) => update("daily_conversation_limit", value)} />
+                </SettingRow>
+              </SettingsSection>
+
+              <section className="settings-section quiet-section">
+                <div className="settings-section-title"><div><strong>勿扰时间</strong><span>提醒和主动聊天共用</span></div><Toggle checked={settings.quiet_hours_enabled} onChange={(value) => update("quiet_hours_enabled", value)} /></div>
+                <div className="quiet-time-row"><input type="time" value={settings.quiet_start} onChange={(event) => update("quiet_start", event.target.value)} /><span>至</span><input type="time" value={settings.quiet_end} onChange={(event) => update("quiet_end", event.target.value)} /></div>
+              </section>
+              {error ? <div className="settings-error" role="alert">{error}</div> : null}
+            </div>
+          )}
+          <footer className="proactive-dialog-footer"><Dialog.Close asChild><button className="secondary-action" disabled={saving}>取消</button></Dialog.Close><button className="primary-action" disabled={saving || loading || !settings} onClick={() => void save()}>{saving ? "保存中…" : "保存设置"}</button></footer>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function SettingsSection({ title, enabled, onEnabled, children }: { title: string; enabled: boolean; onEnabled: (value: boolean) => void; children: ReactNode }) {
+  return <section className={`settings-section${enabled ? "" : " disabled"}`}><div className="settings-section-title"><strong>{title}</strong><Toggle checked={enabled} onChange={onEnabled} /></div><div className="settings-section-content">{children}</div></section>;
+}
+
+function SettingRow({ label, helpId, help, onHelp, helpText, children }: { label: string; helpId: string; help: string; onHelp: (id: string) => void; helpText: string; children: ReactNode }) {
+  return <div className="setting-row"><div className="setting-label"><span>{label}</span><span className="help-owner" onPointerDown={(event) => event.stopPropagation()}><button className="help-button" aria-label={`说明：${label}`} onClick={() => onHelp(help === helpId ? "" : helpId)}><AlertCircle size={13} /></button>{help === helpId ? <span className="help-popover">{helpText}</span> : null}</span></div>{children}</div>;
+}
+
+function Toggle({ checked, onChange }: { checked: boolean; onChange: (value: boolean) => void }) {
+  return <button type="button" className={`toggle${checked ? " on" : ""}`} role="switch" aria-checked={checked} onClick={() => onChange(!checked)}><span /></button>;
+}
+
+function NumberSetting({ value, min, max, suffix, onChange }: { value: number; min: number; max: number; suffix: string; onChange: (value: number) => void }) {
+  return <label className="number-setting"><input type="number" min={min} max={max} value={value} onChange={(event) => onChange(Math.max(min, Math.min(max, Number(event.target.value) || min)))} /><span>{suffix}</span></label>;
+}
+
+function workspaceName(path: string): string {
+  const normalized = path.replace(/[\\/]+$/, "");
+  return normalized.split(/[\\/]/).pop() || path || "工作目录";
+}

--- a/frontend/chat/src/SessionSidebar.tsx
+++ b/frontend/chat/src/SessionSidebar.tsx
@@ -3,10 +3,13 @@ import {
   AlertCircle,
   Bell,
   Folder,
+  FolderOpen,
   FolderPlus,
   MessageSquarePlus,
   MoreHorizontal,
   Pencil,
+  Pin,
+  PinOff,
   Trash2,
   Unlink,
   X,
@@ -18,9 +21,9 @@ import {
   deleteReminder,
   fetchProactiveSettings,
   fetchReminders,
+  pickWorkspaceDirectory,
   saveProactiveSettings,
 } from "./api";
-import { groupSessionsByUpdatedAt } from "./sessionGroups";
 import type {
   ProactiveSettings,
   ScheduledReminder,
@@ -35,11 +38,15 @@ export function SessionSidebar(props: {
   onCreate: (workspaceId?: string | null) => void;
   onDelete: (id: string) => Promise<void>;
   onDeleteWorkspace: (id: string) => Promise<void>;
+  onOpenWorkspace: (id: string) => Promise<void>;
   onRegisterWorkspace: (path: string, title: string) => Promise<Workspace>;
   onRename: (id: string, title: string) => Promise<void>;
+  onSetSessionPinned: (id: string, pinned: boolean) => Promise<void>;
+  onUpdateWorkspace: (id: string, patch: { title?: string; pinned?: boolean }) => Promise<void>;
   onSelect: (id: string) => void;
 }) {
   const [menuSessionId, setMenuSessionId] = useState("");
+  const [menuWorkspaceId, setMenuWorkspaceId] = useState("");
   const [editingSessionId, setEditingSessionId] = useState("");
   const [titleDraft, setTitleDraft] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<SessionSummary | null>(null);
@@ -48,6 +55,10 @@ export function SessionSidebar(props: {
   const [workspacePath, setWorkspacePath] = useState("");
   const [workspaceTitle, setWorkspaceTitle] = useState("");
   const [workspaceError, setWorkspaceError] = useState("");
+  const [pickingWorkspace, setPickingWorkspace] = useState(false);
+  const [renameWorkspaceTarget, setRenameWorkspaceTarget] = useState<Workspace | null>(null);
+  const [workspaceTitleDraft, setWorkspaceTitleDraft] = useState("");
+  const [updatingWorkspace, setUpdatingWorkspace] = useState(false);
   const [proactiveTarget, setProactiveTarget] = useState<SessionSummary | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [deletingWorkspace, setDeletingWorkspace] = useState(false);
@@ -90,17 +101,21 @@ export function SessionSidebar(props: {
   };
 
   useEffect(() => {
-    if (!menuSessionId) return;
+    if (!menuSessionId && !menuWorkspaceId) return;
     const closeMenuOutside = (event: PointerEvent) => {
-      const owner = event.target instanceof Element
+      const sessionOwner = event.target instanceof Element
         ? event.target.closest<HTMLElement>("[data-session-menu-owner]")
         : null;
-      if (owner?.dataset.sessionMenuOwner !== menuSessionId) setMenuSessionId("");
+      const workspaceOwner = event.target instanceof Element
+        ? event.target.closest<HTMLElement>("[data-workspace-menu-owner]")
+        : null;
+      if (sessionOwner?.dataset.sessionMenuOwner !== menuSessionId) setMenuSessionId("");
+      if (workspaceOwner?.dataset.workspaceMenuOwner !== menuWorkspaceId) setMenuWorkspaceId("");
     };
     // 捕获阶段先收起菜单，再执行目标控件自己的动作。
     document.addEventListener("pointerdown", closeMenuOutside, true);
     return () => document.removeEventListener("pointerdown", closeMenuOutside, true);
-  }, [menuSessionId]);
+  }, [menuSessionId, menuWorkspaceId]);
 
   const beginRename = (session: SessionSummary) => {
     setMenuSessionId("");
@@ -119,7 +134,7 @@ export function SessionSidebar(props: {
     await props.onRename(session.key, title).catch(() => setEditingSessionId(session.key));
   };
 
-  const renderSessionRows = (sessions: SessionSummary[]) => sessions.map((session) => {
+  const renderSessionRows = (sessions: SessionSummary[]) => sortSessions(sessions).map((session) => {
     const title = session.title || session.first_message_content || "未命名会话";
     const active = session.key === props.activeSessionId;
     return (
@@ -144,7 +159,7 @@ export function SessionSidebar(props: {
           />
         ) : (
           <button className="session-row-select" onClick={() => props.onSelect(session.key)}>
-            <span>{title}</span>
+            <span>{session.pinned_at ? <Pin className="session-row-pin" size={13} /> : null}{title}</span>
           </button>
         )}
         <button
@@ -157,6 +172,12 @@ export function SessionSidebar(props: {
         </button>
         {menuSessionId === session.key ? (
           <div className="session-menu" role="menu">
+            {session.workspace_id ? (
+              <button role="menuitem" onClick={() => {
+                setMenuSessionId("");
+                void props.onSetSessionPinned(session.key, !session.pinned_at).catch(() => undefined);
+              }}>{session.pinned_at ? <PinOff size={15} /> : <Pin size={15} />}{session.pinned_at ? "取消置顶" : "置顶会话"}</button>
+            ) : null}
             <button role="menuitem" onClick={() => { setMenuSessionId(""); setProactiveTarget(session); }}><Bell size={15} />主动设置</button>
             <button role="menuitem" onClick={() => beginRename(session)}><Pencil size={15} />重命名</button>
             <button className="danger" role="menuitem" onClick={() => { setMenuSessionId(""); setDeleteTarget(session); }}><Trash2 size={15} />删除</button>
@@ -166,12 +187,23 @@ export function SessionSidebar(props: {
     );
   });
 
-  const renderSessions = (sessions: SessionSummary[]) => sessions.length ? groupSessionsByUpdatedAt(sessions).map((group) => (
-    <div className="session-group" key={group.label}>
-      <h3 className="session-group-title">{group.label}</h3>
-      {renderSessionRows(group.sessions)}
-    </div>
-  )) : <p className="workspace-session-empty">尚无会话</p>;
+  const renderSessions = (sessions: SessionSummary[]) => sessions.length
+    ? renderSessionRows(sessions)
+    : <p className="workspace-session-empty">尚无会话</p>;
+
+  const chooseWorkspace = async () => {
+    if (pickingWorkspace || registeringWorkspace) return;
+    setPickingWorkspace(true);
+    setWorkspaceError("");
+    try {
+      const selected = await pickWorkspaceDirectory();
+      if (selected !== null) setWorkspacePath(selected);
+    } catch (error) {
+      setWorkspaceError(error instanceof Error ? error.message : "无法选择工作目录");
+    } finally {
+      setPickingWorkspace(false);
+    }
+  };
 
   const submitWorkspace = async () => {
     const path = workspacePath.trim();
@@ -191,6 +223,12 @@ export function SessionSidebar(props: {
   };
 
   const unassignedSessions = props.sessions.filter((session) => !session.workspace_id);
+  const pinnedWorkspaces = props.workspaces
+    .filter((workspace) => workspace.pinned_at)
+    .sort(comparePinned);
+  const projectWorkspaces = props.workspaces
+    .filter((workspace) => !workspace.pinned_at)
+    .sort((left, right) => compareDateDesc(left.created_at, right.created_at, left.id, right.id));
   const registeredWorkspaceIds = new Set(props.workspaces.map((workspace) => workspace.id));
   const unavailableByWorkspace = new Map<string, {
     id: string;
@@ -217,6 +255,29 @@ export function SessionSidebar(props: {
   }
   const unavailableWorkspaceGroups = [...unavailableByWorkspace.values()];
 
+  const renderWorkspace = (workspace: Workspace) => (
+    <section className="workspace-group" key={workspace.id} data-workspace-id={workspace.id}>
+      <header className="workspace-group-header" data-workspace-menu-owner={workspace.id}>
+        <span className={`workspace-group-icon${workspace.valid ? "" : " invalid"}`}><Folder size={15} /></span>
+        <span className="workspace-group-copy" title={workspace.canonical_path}>
+          <strong>{workspace.title || workspaceName(workspace.canonical_path)}</strong>
+          <small>{workspace.valid ? workspace.canonical_path : "目录不可用"}</small>
+        </span>
+        <button className="workspace-header-action" aria-label={`在“${workspace.title || workspaceName(workspace.canonical_path)}”中新建会话`} title="新建会话" disabled={!workspace.valid} onClick={() => props.onCreate(workspace.id)}><MessageSquarePlus size={15} /></button>
+        <button className="workspace-header-action" aria-label={`打开工作目录“${workspace.title || workspaceName(workspace.canonical_path)}”的菜单`} aria-expanded={menuWorkspaceId === workspace.id} title="工作目录菜单" onClick={() => setMenuWorkspaceId((current) => current === workspace.id ? "" : workspace.id)}><MoreHorizontal size={16} /></button>
+        {menuWorkspaceId === workspace.id ? (
+          <div className="workspace-menu" role="menu">
+            <button role="menuitem" onClick={() => { setMenuWorkspaceId(""); void props.onUpdateWorkspace(workspace.id, { pinned: !workspace.pinned_at }).catch(() => undefined); }}>{workspace.pinned_at ? <PinOff size={15} /> : <Pin size={15} />}{workspace.pinned_at ? "取消置顶" : "置顶项目"}</button>
+            <button role="menuitem" onClick={() => { setMenuWorkspaceId(""); setWorkspaceTitleDraft(workspace.title); setRenameWorkspaceTarget(workspace); }}><Pencil size={15} />修改名称</button>
+            <button role="menuitem" disabled={!workspace.valid} onClick={() => { setMenuWorkspaceId(""); void props.onOpenWorkspace(workspace.id).catch(() => undefined); }}><FolderOpen size={15} />在资源管理器中打开</button>
+            <button className="danger" role="menuitem" onClick={() => { setMenuWorkspaceId(""); setDeleteWorkspaceTarget(workspace); }}><Unlink size={15} />移除工作目录</button>
+          </div>
+        ) : null}
+      </header>
+      <div className="workspace-sessions">{renderSessions(props.sessions.filter((session) => session.workspace_id === workspace.id))}</div>
+    </section>
+  );
+
   return (
     <div className="session-panel">
       <div className="brand-lockup">
@@ -225,7 +286,12 @@ export function SessionSidebar(props: {
       </div>
       <div className="sidebar-primary-actions">
         <button className="new-chat-button" onClick={() => props.onCreate(null)}><MessageSquarePlus size={17} />新建会话</button>
-        <button className="add-workspace-button" onClick={() => { setWorkspaceError(""); setWorkspaceDialogOpen(true); }}><FolderPlus size={17} />添加工作目录</button>
+        <button className="add-workspace-button" onClick={() => {
+          setWorkspaceError("");
+          setWorkspacePath("");
+          setWorkspaceTitle("");
+          setWorkspaceDialogOpen(true);
+        }}><FolderPlus size={17} />添加工作目录</button>
       </div>
       <nav
         ref={sessionListRef}
@@ -234,31 +300,13 @@ export function SessionSidebar(props: {
         onPointerEnter={showSessionScrollbar}
         onPointerLeave={scheduleSessionScrollbarHide}
       >
-        <section className="workspace-group" data-workspace-id="none">
-          <header className="workspace-group-header">
-            <span className="workspace-group-icon"><Folder size={15} /></span>
-            <span className="workspace-group-copy"><strong>无工作目录</strong><small>会话私有临时目录</small></span>
-            <button className="workspace-header-action" aria-label="在无工作目录中新建会话" title="新建会话" onClick={() => props.onCreate(null)}><MessageSquarePlus size={15} /></button>
-          </header>
-          <div className="workspace-sessions">{renderSessions(unassignedSessions)}</div>
-        </section>
-        {props.workspaces.map((workspace) => (
-          <section className="workspace-group" key={workspace.id} data-workspace-id={workspace.id}>
-            <header className="workspace-group-header">
-              <span className={`workspace-group-icon${workspace.valid ? "" : " invalid"}`}><Folder size={15} /></span>
-              <span className="workspace-group-copy" title={workspace.canonical_path}>
-                <strong>{workspace.title || workspaceName(workspace.canonical_path)}</strong>
-                <small>{workspace.valid ? workspace.canonical_path : "目录不可用"}</small>
-              </span>
-              <button className="workspace-header-action" aria-label={`在“${workspace.title || workspaceName(workspace.canonical_path)}”中新建会话`} title="新建会话" disabled={!workspace.valid} onClick={() => props.onCreate(workspace.id)}><MessageSquarePlus size={15} /></button>
-              <button className="workspace-header-action" aria-label={`移除工作目录“${workspace.title || workspaceName(workspace.canonical_path)}”`} title="移除工作目录" onClick={() => setDeleteWorkspaceTarget(workspace)}><Unlink size={15} /></button>
-            </header>
-            <div className="workspace-sessions">{renderSessions(props.sessions.filter((session) => session.workspace_id === workspace.id))}</div>
-          </section>
-        ))}
+        {pinnedWorkspaces.length ? <h2 className="sidebar-section-label">置顶</h2> : null}
+        {pinnedWorkspaces.map(renderWorkspace)}
+        {projectWorkspaces.length || unavailableWorkspaceGroups.length ? <h2 className="sidebar-section-label">项目</h2> : null}
+        {projectWorkspaces.map(renderWorkspace)}
         {unavailableWorkspaceGroups.map((workspace) => (
           <section className="workspace-group" key={`unavailable:${workspace.id}`} data-workspace-id={workspace.id}>
-            <header className="workspace-group-header">
+            <header className="workspace-group-header unavailable-header">
               <span className="workspace-group-icon invalid"><Folder size={15} /></span>
               <span className="workspace-group-copy" title={workspace.path || undefined}>
                 <strong>{workspace.title}</strong>
@@ -268,6 +316,11 @@ export function SessionSidebar(props: {
             <div className="workspace-sessions">{renderSessions(workspace.sessions)}</div>
           </section>
         ))}
+        <div className="sidebar-section-heading recent-heading">
+          <h2 className="sidebar-section-label recent-label">最近</h2>
+          <button className="workspace-header-action" aria-label="在最近中新建会话" title="新建会话" onClick={() => props.onCreate(null)}><MessageSquarePlus size={15} /></button>
+        </div>
+        <div className="recent-sessions" data-workspace-id="none">{renderSessions(unassignedSessions)}</div>
       </nav>
       <Dialog.Root open={deleteTarget !== null} onOpenChange={(open) => { if (!open && !deleting) setDeleteTarget(null); }}>
         <Dialog.Portal>
@@ -298,24 +351,82 @@ export function SessionSidebar(props: {
         </Dialog.Portal>
       </Dialog.Root>
       <Dialog.Root open={workspaceDialogOpen} onOpenChange={(open) => {
-        if (registeringWorkspace) return;
+        if (registeringWorkspace || pickingWorkspace) return;
         setWorkspaceDialogOpen(open);
         if (!open) setWorkspaceError("");
       }}>
         <Dialog.Portal>
           <Dialog.Overlay className="dialog-overlay" />
-          <Dialog.Content className="workspace-dialog">
+          <Dialog.Content className="workspace-dialog workspace-create-dialog">
             <div className="workspace-dialog-header">
-              <div><Dialog.Title>添加工作目录</Dialog.Title><Dialog.Description>注册本机已有目录，用于限定会话的可写范围。</Dialog.Description></div>
-              <Dialog.Close asChild><button className="icon-button" aria-label="关闭" disabled={registeringWorkspace}><X size={17} /></button></Dialog.Close>
+              <div><Dialog.Title>添加工作目录</Dialog.Title><Dialog.Description className="sr-only">注册本机已有目录，用于限定会话的可写范围。</Dialog.Description></div>
+              <Dialog.Close asChild><button className="icon-button" aria-label="关闭" disabled={registeringWorkspace || pickingWorkspace}><X size={17} /></button></Dialog.Close>
             </div>
             <form onSubmit={(event) => { event.preventDefault(); void submitWorkspace(); }}>
-              <label>绝对路径<input autoFocus value={workspacePath} onChange={(event) => setWorkspacePath(event.target.value)} placeholder="D:\code\project" /></label>
-              <label>显示名称 <span>可选</span><input value={workspaceTitle} maxLength={80} onChange={(event) => setWorkspaceTitle(event.target.value)} placeholder="默认使用文件夹名称" /></label>
+              <label className="workspace-name-field">
+                <span className="sr-only">显示名称（可选）</span>
+                <Folder size={20} aria-hidden="true" />
+                <input
+                  value={workspaceTitle}
+                  maxLength={80}
+                  onChange={(event) => setWorkspaceTitle(event.target.value)}
+                  placeholder="项目名称（可选）"
+                />
+              </label>
+              <div className="workspace-picker-field">
+                <span className="workspace-field-label">源文件夹</span>
+                <button
+                  type="button"
+                  className={`workspace-picker-card${workspacePath ? " selected" : ""}`}
+                  disabled={pickingWorkspace || registeringWorkspace}
+                  onClick={() => void chooseWorkspace()}
+                  title={workspacePath || "选择工作目录"}
+                  aria-label={workspacePath ? `重新选择工作目录，当前为 ${workspacePath}` : "选择 Bean 可读取和编辑的文件夹"}
+                >
+                  <span className="workspace-picker-icon">
+                    {workspacePath ? <FolderOpen size={26} /> : <FolderPlus size={26} />}
+                  </span>
+                  <span className="workspace-picker-copy">
+                    <strong>{workspacePath
+                      ? workspaceName(workspacePath)
+                      : "添加 Bean 可读取和编辑的文件夹"}</strong>
+                    {workspacePath ? <small>{workspacePath}</small> : null}
+                  </span>
+                </button>
+              </div>
               {workspaceError ? <p className="workspace-form-error" role="alert">{workspaceError}</p> : null}
               <footer className="workspace-dialog-actions">
-                <Dialog.Close asChild><button type="button" className="secondary-action" disabled={registeringWorkspace}>取消</button></Dialog.Close>
-                <button type="submit" className="primary-action" disabled={registeringWorkspace || !workspacePath.trim()}>{registeringWorkspace ? "添加中…" : "添加"}</button>
+                <Dialog.Close asChild><button type="button" className="secondary-action" disabled={registeringWorkspace || pickingWorkspace}>取消</button></Dialog.Close>
+                <button type="submit" className="primary-action" disabled={registeringWorkspace || pickingWorkspace || !workspacePath.trim()}>{registeringWorkspace ? "添加中…" : "添加"}</button>
+              </footer>
+            </form>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+      <Dialog.Root open={renameWorkspaceTarget !== null} onOpenChange={(open) => {
+        if (!open && !updatingWorkspace) setRenameWorkspaceTarget(null);
+      }}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="dialog-overlay" />
+          <Dialog.Content className="workspace-dialog rename-workspace-dialog">
+            <div className="workspace-dialog-header">
+              <div><Dialog.Title>修改项目名称</Dialog.Title><Dialog.Description>只修改 BeanAgent 中显示的名称，不会重命名磁盘文件夹。</Dialog.Description></div>
+              <Dialog.Close asChild><button className="icon-button" aria-label="关闭" disabled={updatingWorkspace}><X size={17} /></button></Dialog.Close>
+            </div>
+            <form onSubmit={(event) => {
+              event.preventDefault();
+              const title = workspaceTitleDraft.trim();
+              if (!renameWorkspaceTarget || !title || updatingWorkspace) return;
+              setUpdatingWorkspace(true);
+              void props.onUpdateWorkspace(renameWorkspaceTarget.id, { title })
+                .then(() => setRenameWorkspaceTarget(null))
+                .catch(() => undefined)
+                .finally(() => setUpdatingWorkspace(false));
+            }}>
+              <label>项目名称<input autoFocus value={workspaceTitleDraft} maxLength={80} onChange={(event) => setWorkspaceTitleDraft(event.target.value)} /></label>
+              <footer className="workspace-dialog-actions">
+                <Dialog.Close asChild><button type="button" className="secondary-action" disabled={updatingWorkspace}>取消</button></Dialog.Close>
+                <button type="submit" className="primary-action" disabled={updatingWorkspace || !workspaceTitleDraft.trim()}>{updatingWorkspace ? "保存中…" : "保存"}</button>
               </footer>
             </form>
           </Dialog.Content>
@@ -498,4 +609,32 @@ function NumberSetting({ value, min, max, suffix, onChange }: { value: number; m
 function workspaceName(path: string): string {
   const normalized = path.replace(/[\\/]+$/, "");
   return normalized.split(/[\\/]/).pop() || path || "工作目录";
+}
+
+function compareDateDesc(left: string, right: string, leftId: string, rightId: string): number {
+  const byDate = Date.parse(right) - Date.parse(left);
+  return Number.isNaN(byDate) || byDate === 0 ? rightId.localeCompare(leftId) : byDate;
+}
+
+function comparePinned<T extends { pinned_at?: string | null; id?: string; key?: string }>(left: T, right: T): number {
+  const leftTime = left.pinned_at ? Date.parse(left.pinned_at) : Number.POSITIVE_INFINITY;
+  const rightTime = right.pinned_at ? Date.parse(right.pinned_at) : Number.POSITIVE_INFINITY;
+  const byDate = leftTime - rightTime;
+  return Number.isNaN(byDate) || byDate === 0
+    ? (left.id ?? left.key ?? "").localeCompare(right.id ?? right.key ?? "")
+    : byDate;
+}
+
+function sortSessions(sessions: SessionSummary[]): SessionSummary[] {
+  return [...sessions].sort((left, right) => {
+    if (left.pinned_at && right.pinned_at) return comparePinned(left, right);
+    if (left.pinned_at) return -1;
+    if (right.pinned_at) return 1;
+    return compareDateDesc(
+      left.last_activity_at || left.created_at,
+      right.last_activity_at || right.created_at,
+      left.key,
+      right.key,
+    );
+  });
 }

--- a/frontend/chat/src/api.ts
+++ b/frontend/chat/src/api.ts
@@ -1,4 +1,4 @@
-import type { MessagePage, MessageRow, ProactiveNotificationRow, ProactiveSettings, ScheduledReminder, SessionSummary, TurnNavigationEntry, UploadedFile } from "./types";
+import type { MessagePage, MessageRow, ProactiveNotificationRow, ProactiveSettings, ScheduledReminder, SessionSummary, TurnNavigationEntry, UploadedFile, Workspace } from "./types";
 
 // 仅控制聊天页面的滚动分页，不参与模型上下文 token gate 或 checkpoint 边界。
 const MESSAGE_WINDOW_LIMIT = 60;
@@ -8,6 +8,36 @@ export async function fetchSessions(): Promise<SessionSummary[]> {
   if (!response.ok) throw new Error("无法加载会话列表");
   const payload = await response.json() as { items?: SessionSummary[] };
   return payload.items ?? [];
+}
+
+export async function fetchWorkspaces(): Promise<Workspace[]> {
+  const response = await fetch("/api/chat/workspaces");
+  if (!response.ok) throw new Error("无法加载工作目录");
+  const payload = await response.json() as { items?: Workspace[] };
+  return (payload.items ?? []).filter((item) => (
+    typeof item?.id === "string" && typeof item.canonical_path === "string"
+  ));
+}
+
+export async function registerWorkspace(path: string, title: string): Promise<Workspace> {
+  const response = await fetch("/api/chat/workspaces", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ path, title }),
+  });
+  const payload = await response.json().catch(() => ({})) as Partial<Workspace> & { detail?: string };
+  if (!response.ok || !payload.id) throw new Error(payload.detail || "无法添加工作目录");
+  return payload as Workspace;
+}
+
+export async function deleteWorkspace(workspaceId: string): Promise<void> {
+  const response = await fetch(`/api/chat/workspaces/${encodeURIComponent(workspaceId)}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({})) as { detail?: string };
+    throw new Error(payload.detail || "无法移除工作目录");
+  }
 }
 
 export async function fetchMessages(sessionId: string): Promise<MessageRow[]> {

--- a/frontend/chat/src/api.ts
+++ b/frontend/chat/src/api.ts
@@ -30,6 +30,37 @@ export async function registerWorkspace(path: string, title: string): Promise<Wo
   return payload as Workspace;
 }
 
+export async function pickWorkspaceDirectory(): Promise<string | null> {
+  const response = await fetch("/api/chat/workspaces/pick", { method: "POST" });
+  const payload = await response.json().catch(() => ({})) as { path?: string | null; detail?: string };
+  if (!response.ok) throw new Error(payload.detail || "无法打开系统文件夹选择器");
+  return typeof payload.path === "string" ? payload.path : null;
+}
+
+export async function updateWorkspace(
+  workspaceId: string,
+  patch: { title?: string; pinned?: boolean },
+): Promise<Workspace> {
+  const response = await fetch(`/api/chat/workspaces/${encodeURIComponent(workspaceId)}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(patch),
+  });
+  const payload = await response.json().catch(() => ({})) as Partial<Workspace> & { detail?: string };
+  if (!response.ok || !payload.id) throw new Error(payload.detail || "无法更新工作目录");
+  return payload as Workspace;
+}
+
+export async function openWorkspaceDirectory(workspaceId: string): Promise<void> {
+  const response = await fetch(`/api/chat/workspaces/${encodeURIComponent(workspaceId)}/open`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({})) as { detail?: string };
+    throw new Error(payload.detail || "无法在资源管理器中打开工作目录");
+  }
+}
+
 export async function deleteWorkspace(workspaceId: string): Promise<void> {
   const response = await fetch(`/api/chat/workspaces/${encodeURIComponent(workspaceId)}`, {
     method: "DELETE",
@@ -101,6 +132,18 @@ export async function renameSession(sessionId: string, title: string): Promise<S
     throw new Error(payload.detail || "无法重命名会话");
   }
   return response.json() as Promise<SessionSummary>;
+}
+
+export async function setSessionPinned(sessionId: string, pinned: boolean): Promise<void> {
+  const response = await fetch(`/api/chat/sessions/${encodeURIComponent(sessionId)}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ pinned }),
+  });
+  if (!response.ok) {
+    const payload = await response.json().catch(() => ({})) as { detail?: string };
+    throw new Error(payload.detail || "无法更新会话置顶状态");
+  }
 }
 
 export async function deleteSession(sessionId: string): Promise<void> {

--- a/frontend/chat/src/chatReducer.ts
+++ b/frontend/chat/src/chatReducer.ts
@@ -93,18 +93,23 @@ export function reduceChatFrame(state: ChatState, action: ChatAction): ChatState
   }
   if (action.type === "session.subscribed") return state;
   if (action.type === "error") {
+    const requestSessionId = Object.entries(state.turnStates)
+      .find(([, turn]) => turn.requestId && turn.requestId === action.request_id)?.[0];
     const rejected = action.code === "queue_full" || action.code === "session_busy" || action.code === "closed";
-    if (!rejected || !action.session_id) return { ...state, error: action.message };
-    const current = action.session_id === state.sessionId;
-    const sessionMessages = getSessionMessages(state, action.session_id)
+    const failedSessionId = rejected ? action.session_id : requestSessionId;
+    if (!failedSessionId) return { ...state, error: action.message };
+    // 首轮创建 Session 后错误帧可能省略 session_id，必须通过 request id 找回已迁移的
+    // submitting 状态，否则输入框会永久停留在“停止”按钮。
+    const current = failedSessionId === state.sessionId;
+    const sessionMessages = getSessionMessages(state, failedSessionId)
       .filter((message) => message.id !== `user-${action.request_id}`);
     return {
       ...state,
       activeTurnId: current ? "" : state.activeTurnId,
       messages: current ? sessionMessages : state.messages,
-      sessionMessages: setSessionMessages(state, action.session_id, sessionMessages),
+      sessionMessages: setSessionMessages(state, failedSessionId, sessionMessages),
       error: current ? action.message : state.error,
-      turnStates: setTurnState(state, action.session_id, idleTurnState),
+      turnStates: setTurnState(state, failedSessionId, idleTurnState),
     };
   }
   if (action.type === "pong") return state;

--- a/frontend/chat/src/styles.css
+++ b/frontend/chat/src/styles.css
@@ -164,9 +164,14 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
 .session-list.scrollbar-visible::-webkit-scrollbar-thumb { background-color: rgba(116, 126, 122, .36); }
 .session-list.scrollbar-visible::-webkit-scrollbar-thumb:hover { background-color: rgba(116, 126, 122, .52); }
 .session-list::-webkit-scrollbar-button { display: none; width: 0; height: 0; }
+.sidebar-section-label { margin: 16px 6px 7px; color: var(--text-subtle); font-size: 11px; font-weight: 650; line-height: 1.2; }
+.sidebar-section-label:first-child { margin-top: 2px; }
+.sidebar-section-heading { display: flex; min-height: 32px; align-items: end; justify-content: space-between; }
+.sidebar-section-heading .sidebar-section-label { flex: 1; }
+.sidebar-section-heading .workspace-header-action { margin: 0 2px 2px 0; }
 .workspace-group + .workspace-group { margin-top: 14px; }
-.workspace-group-header { display: grid; grid-template-columns: 24px minmax(0, 1fr) 26px 26px; min-height: 40px; align-items: center; gap: 2px; padding: 3px 2px 5px; }
-.workspace-group:first-child .workspace-group-header { grid-template-columns: 24px minmax(0, 1fr) 26px; }
+.workspace-group-header { position: relative; display: grid; grid-template-columns: 24px minmax(0, 1fr) 26px 26px; min-height: 40px; align-items: center; gap: 2px; padding: 3px 2px 5px; }
+.workspace-group-header.unavailable-header { grid-template-columns: 24px minmax(0, 1fr); }
 .workspace-group-icon { display: grid; width: 24px; height: 24px; place-items: center; color: var(--primary-icon); }
 .workspace-group-icon.invalid { color: var(--warning); }
 .workspace-group-copy { display: flex; min-width: 0; flex-direction: column; gap: 1px; }
@@ -176,7 +181,13 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
 .workspace-header-action { display: grid; width: 26px; height: 26px; padding: 0; place-items: center; border: 0; border-radius: 4px; background: transparent; color: var(--text-subtle); cursor: pointer; }
 .workspace-header-action:hover:not(:disabled) { background: var(--surface-hover); color: var(--primary-hover); }
 .workspace-header-action:disabled { cursor: default; opacity: .38; }
+.workspace-menu { position: absolute; z-index: 6; top: 35px; right: 0; min-width: 190px; padding: 4px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); box-shadow: 0 8px 20px rgba(28, 43, 38, .16); }
+.workspace-menu button { display: flex; width: 100%; min-height: 32px; align-items: center; gap: 8px; padding: 0 8px; border: 0; border-radius: 4px; background: transparent; cursor: pointer; font-size: 13px; text-align: left; }
+.workspace-menu button:hover:not(:disabled) { background: var(--surface-3); }
+.workspace-menu button:disabled { cursor: default; opacity: .45; }
+.workspace-menu button.danger { color: var(--danger); }
 .workspace-sessions { padding-left: 6px; }
+.recent-sessions { padding-left: 6px; }
 .workspace-session-empty { margin: 3px 7px 5px; color: var(--text-faint); font-size: 11px; }
 .session-group + .session-group { margin-top: 11px; }
 .session-group-title { margin: 2px 8px 4px; color: var(--text-subtle); font-size: 10px; font-weight: 600; letter-spacing: 0; }
@@ -185,6 +196,7 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
 .session-row.active { background: var(--primary-wash); }
 .session-row-select { display: block; min-width: 0; min-height: 42px; padding: 9px 5px 9px 7px; overflow: hidden; border: 0; background: transparent; cursor: pointer; text-align: left; }
 .session-row-select > span { display: block; overflow: hidden; font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
+.session-row-pin { margin-right: 5px; vertical-align: -2px; color: var(--primary-icon); }
 .session-menu-trigger { display: grid; align-self: center; place-items: center; width: 28px; height: 28px; padding: 0; border: 0; border-radius: 4px; background: transparent; cursor: pointer; opacity: 0; }
 .session-row:hover .session-menu-trigger, .session-row.active .session-menu-trigger, .session-menu-trigger:focus-visible, .session-menu-trigger[aria-expanded="true"] { opacity: 1; }
 .session-menu-trigger:hover { background: #dfe7e3; }
@@ -210,6 +222,28 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
 .workspace-dialog form > label > span { margin-left: 3px; color: var(--text-faint); font-size: 11px; font-weight: 400; }
 .workspace-dialog input { width: 100%; height: 38px; padding: 0 10px; border: 1px solid var(--border-input); border-radius: 5px; outline: none; background: var(--surface-2); color: var(--text); }
 .workspace-dialog input:focus { border-color: var(--primary); box-shadow: 0 0 0 2px var(--primary-tint); }
+.workspace-create-dialog { width: min(510px, calc(100vw - 32px)); padding: 26px; }
+.workspace-create-dialog .workspace-dialog-header { margin-bottom: 22px; }
+.workspace-create-dialog form { gap: 20px; }
+.workspace-name-field { position: relative; display: block; }
+.workspace-name-field > svg { position: absolute; z-index: 1; top: 50%; left: 16px; color: var(--primary-icon); transform: translateY(-50%); pointer-events: none; }
+.workspace-create-dialog .workspace-name-field > input { height: 48px; padding: 0 16px 0 49px; border-radius: 6px; background: var(--surface); font-size: 14px; }
+.workspace-picker-field { display: grid; gap: 10px; }
+.workspace-field-label { color: var(--text-strong); font-size: 14px; font-weight: 650; }
+.workspace-picker-card { display: flex; width: 100%; min-height: 142px; align-items: center; justify-content: center; flex-direction: column; gap: 10px; padding: 24px; border: 1px solid var(--border-input); border-radius: 8px; background: var(--surface); cursor: pointer; text-align: center; transition: border-color .15s ease, background .15s ease, box-shadow .15s ease; }
+.workspace-picker-card:hover:not(:disabled), .workspace-picker-card:focus-visible { border-color: var(--primary-border); background: var(--primary-soft-2); box-shadow: 0 0 0 2px var(--primary-tint); outline: none; }
+.workspace-picker-card.selected { border-color: var(--primary-border); background: var(--primary-soft-2); }
+.workspace-picker-card:disabled { cursor: default; opacity: .7; }
+.workspace-picker-icon { display: grid; width: 32px; height: 32px; place-items: center; color: var(--primary-icon); }
+.workspace-picker-copy { display: flex; width: 100%; min-width: 0; align-items: center; flex-direction: column; gap: 5px; }
+.workspace-picker-copy strong, .workspace-picker-copy small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.workspace-picker-copy strong { max-width: 100%; color: var(--text-strong); font-size: 15px; font-weight: 600; }
+.workspace-picker-copy small { max-width: 100%; color: var(--text-subtle); font-size: 12px; font-weight: 400; }
+.workspace-create-dialog .workspace-dialog-actions { margin-top: 0; }
+.workspace-create-dialog .workspace-dialog-actions button { min-height: 42px; padding: 0 18px; }
+.workspace-create-dialog .workspace-dialog-actions .secondary-action { border-color: transparent; color: var(--text-muted); background: transparent; }
+.workspace-create-dialog .workspace-dialog-actions .secondary-action:hover { color: var(--text); background: var(--surface-3); }
+.rename-workspace-dialog { width: min(420px, calc(100vw - 32px)); }
 .workspace-form-error { margin: -4px 0 0; color: var(--danger-text); font-size: 12px; line-height: 1.45; }
 .workspace-dialog-actions, .risk-dialog-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 5px; }
 .workspace-dialog-actions button, .risk-dialog-actions button, .approval-actions button { min-height: 36px; padding: 0 14px; border-radius: 5px; cursor: pointer; font-weight: 600; }
@@ -658,10 +692,12 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
 :root[data-theme="dark"] .user-message .message-body { border-color: var(--border-soft); background: var(--surface-3); }
 :root[data-theme="dark"] .session-row:hover { background: var(--surface-hover); }
 :root[data-theme="dark"] .session-row.active { background: var(--primary-wash); }
-:root[data-theme="dark"] .session-menu { box-shadow: 0 8px 20px rgba(0, 0, 0, .28); }
+:root[data-theme="dark"] .session-menu,
+:root[data-theme="dark"] .workspace-menu { box-shadow: 0 8px 20px rgba(0, 0, 0, .28); }
 :root[data-theme="dark"] .delete-session-dialog { box-shadow: var(--shadow-lg); }
 :root[data-theme="dark"] .delete-session-dialog p { color: var(--text-faint); }
-:root[data-theme="dark"] .workspace-dialog input { border-color: var(--border-input); background: var(--surface-2); }
+:root[data-theme="dark"] .workspace-dialog input,
+:root[data-theme="dark"] .workspace-picker-card { border-color: var(--border-input); background: var(--surface-2); }
 :root[data-theme="dark"] .risk-acknowledgement { border-color: var(--warning-border); background: var(--warning-soft); color: var(--warning-text); }
 
 @media (max-width: 760px) {
@@ -698,6 +734,8 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
   .approval-body { max-height: min(190px, 28vh); }
   .approval-arguments > div { grid-template-columns: 76px minmax(0, 1fr); }
   .speech-toast { top: 9px; left: 50%; }
+  .workspace-create-dialog { padding: 22px; }
+  .workspace-picker-card { min-height: 132px; padding: 20px 14px; }
   .composer-hint { display: none; }
   .send-button { min-width: 38px; width: 38px; padding: 0; }
   .send-button span { display: none; }

--- a/frontend/chat/src/styles.css
+++ b/frontend/chat/src/styles.css
@@ -151,8 +151,11 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
 .brand-lockup div, .brand-compact div { display: flex; flex-direction: column; min-width: 0; }
 .brand-lockup strong, .brand-compact strong { font-size: 16px; line-height: 1.25; font-weight: 600; letter-spacing: -0.02em; }
 .brand-mark, .empty-mark { display: grid; flex: 0 0 auto; place-items: center; width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg, var(--primary), var(--primary-hover)); color: white; font-family: "Inter", "Aptos", sans-serif; font-weight: 700; font-size: 15px; box-shadow: 0 2px 8px rgba(11, 118, 110, .3); }
+.sidebar-primary-actions { display: grid; gap: 7px; }
 .new-chat-button { display: flex; align-items: center; justify-content: center; gap: 8px; min-height: 40px; border: 1px solid #b9c6c2; border-radius: 6px; background: var(--surface-2); cursor: pointer; font-weight: 650; }
 .new-chat-button:hover { border-color: var(--primary); color: var(--primary-hover); }
+.add-workspace-button { display: flex; min-height: 34px; align-items: center; justify-content: center; gap: 8px; border: 0; border-radius: 5px; background: transparent; color: var(--text-muted); cursor: pointer; font-size: 13px; }
+.add-workspace-button:hover { background: var(--surface-hover); color: var(--primary-hover); }
 .session-list { flex: 1 1 0; min-height: 0; margin-top: 14px; overflow-x: hidden; overflow-y: auto; overscroll-behavior: contain; scrollbar-color: transparent transparent; scrollbar-gutter: stable; scrollbar-width: thin; }
 .session-list.scrollbar-visible { scrollbar-color: rgba(116, 126, 122, .36) transparent; }
 .session-list::-webkit-scrollbar { width: 8px; }
@@ -161,8 +164,22 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
 .session-list.scrollbar-visible::-webkit-scrollbar-thumb { background-color: rgba(116, 126, 122, .36); }
 .session-list.scrollbar-visible::-webkit-scrollbar-thumb:hover { background-color: rgba(116, 126, 122, .52); }
 .session-list::-webkit-scrollbar-button { display: none; width: 0; height: 0; }
-.session-group + .session-group { margin-top: 16px; }
-.session-group-title { margin: 0 10px 5px; color: var(--text-subtle); font-size: 12px; font-weight: 650; letter-spacing: 0; }
+.workspace-group + .workspace-group { margin-top: 14px; }
+.workspace-group-header { display: grid; grid-template-columns: 24px minmax(0, 1fr) 26px 26px; min-height: 40px; align-items: center; gap: 2px; padding: 3px 2px 5px; }
+.workspace-group:first-child .workspace-group-header { grid-template-columns: 24px minmax(0, 1fr) 26px; }
+.workspace-group-icon { display: grid; width: 24px; height: 24px; place-items: center; color: var(--primary-icon); }
+.workspace-group-icon.invalid { color: var(--warning); }
+.workspace-group-copy { display: flex; min-width: 0; flex-direction: column; gap: 1px; }
+.workspace-group-copy strong, .workspace-group-copy small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.workspace-group-copy strong { color: var(--text); font-size: 12px; font-weight: 650; }
+.workspace-group-copy small { color: var(--text-subtle); font-size: 10px; }
+.workspace-header-action { display: grid; width: 26px; height: 26px; padding: 0; place-items: center; border: 0; border-radius: 4px; background: transparent; color: var(--text-subtle); cursor: pointer; }
+.workspace-header-action:hover:not(:disabled) { background: var(--surface-hover); color: var(--primary-hover); }
+.workspace-header-action:disabled { cursor: default; opacity: .38; }
+.workspace-sessions { padding-left: 6px; }
+.workspace-session-empty { margin: 3px 7px 5px; color: var(--text-faint); font-size: 11px; }
+.session-group + .session-group { margin-top: 11px; }
+.session-group-title { margin: 2px 8px 4px; color: var(--text-subtle); font-size: 10px; font-weight: 600; letter-spacing: 0; }
 .session-row { position: relative; display: grid; grid-template-columns: minmax(0, 1fr) 28px; width: 100%; min-height: 42px; border-radius: 8px; background: transparent; }
 .session-row:hover { background: var(--surface-hover); }
 .session-row.active { background: var(--primary-wash); }
@@ -184,6 +201,25 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
 .delete-dialog-actions .confirm-delete { border-color: var(--danger); background: var(--danger-strong); color: #fff; }
 .delete-dialog-actions button:disabled { cursor: wait; opacity: .65; }
 .session-empty { margin: 10px; color: var(--text-subtle); font-size: 12px; line-height: 1.55; }
+.workspace-dialog, .risk-dialog { position: fixed; z-index: 31; top: 50%; left: 50%; width: min(470px, calc(100vw - 32px)); padding: 22px; transform: translate(-50%, -50%); border: 1px solid var(--border); border-radius: 8px; background: var(--surface); box-shadow: var(--shadow-lg); animation: dialog-in .18s ease-out; }
+.workspace-dialog-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+.workspace-dialog h2, .risk-dialog h2 { margin: 0; color: var(--text-strong); font-size: 18px; }
+.workspace-dialog [data-radix-dialog-description], .risk-dialog [data-radix-dialog-description] { margin: 5px 0 0; color: var(--text-muted); font-size: 13px; line-height: 1.55; }
+.workspace-dialog form { display: grid; gap: 14px; }
+.workspace-dialog form > label { display: grid; gap: 6px; color: var(--text); font-size: 13px; font-weight: 600; }
+.workspace-dialog form > label > span { margin-left: 3px; color: var(--text-faint); font-size: 11px; font-weight: 400; }
+.workspace-dialog input { width: 100%; height: 38px; padding: 0 10px; border: 1px solid var(--border-input); border-radius: 5px; outline: none; background: var(--surface-2); color: var(--text); }
+.workspace-dialog input:focus { border-color: var(--primary); box-shadow: 0 0 0 2px var(--primary-tint); }
+.workspace-form-error { margin: -4px 0 0; color: var(--danger-text); font-size: 12px; line-height: 1.45; }
+.workspace-dialog-actions, .risk-dialog-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 5px; }
+.workspace-dialog-actions button, .risk-dialog-actions button, .approval-actions button { min-height: 36px; padding: 0 14px; border-radius: 5px; cursor: pointer; font-weight: 600; }
+.workspace-dialog-actions button:disabled, .risk-dialog-actions button:disabled, .approval-actions button:disabled { cursor: default; opacity: .58; }
+.risk-dialog { width: min(430px, calc(100vw - 32px)); }
+.risk-dialog-icon { display: grid; width: 38px; height: 38px; margin-bottom: 13px; place-items: center; border-radius: 50%; background: var(--danger-soft); color: var(--danger); }
+.risk-acknowledgement { display: grid; grid-template-columns: 18px minmax(0, 1fr); align-items: start; gap: 9px; margin: 18px 0; padding: 11px; border: 1px solid var(--warning-border); border-radius: 6px; background: var(--warning-soft); color: var(--warning-text); cursor: pointer; font-size: 12px; line-height: 1.5; }
+.risk-acknowledgement input { width: 16px; height: 16px; margin: 1px 0 0; accent-color: var(--danger); }
+.danger-action { border: 1px solid var(--danger); background: var(--danger-strong); color: #fff; }
+.danger-action:hover:not(:disabled) { background: var(--danger-hover); }
 
 .chat-workspace { position: relative; display: grid; grid-template-areas: "topbar" "error" "conversation" "composer"; grid-template-rows: 58px auto minmax(0, 1fr) max-content; min-width: 0; min-height: 0; height: 100%; overflow: hidden; background: var(--surface-raised); }
 .topbar { grid-area: topbar; display: flex; align-items: center; justify-content: space-between; min-width: 0; padding: 0 22px; border-bottom: 1px solid var(--border-soft); background: rgba(251, 252, 251, .96); }
@@ -447,6 +483,23 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
 .compaction-notice svg { animation: compaction-spin 1.1s linear infinite; }
 @keyframes compaction-spin { to { transform: rotate(360deg); } }
 .composer-actions { display: flex; align-items: center; gap: 8px; min-height: 40px; padding: 3px 8px 8px; }
+.composer-select { position: relative; min-width: 0; }
+.composer-select-trigger { display: inline-flex; max-width: 178px; height: 34px; align-items: center; gap: 5px; padding: 0 7px; border: 0; border-radius: 6px; background: transparent; color: var(--text-muted); cursor: pointer; font-size: 12px; }
+.composer-select-trigger:hover:not(:disabled), .composer-select-trigger[aria-expanded="true"] { background: var(--surface-3); color: var(--text); }
+.composer-select-trigger:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--primary-tint); }
+.composer-select-trigger:disabled { cursor: default; opacity: .5; }
+.composer-select-icon, .composer-option-icon { display: inline-flex; flex: 0 0 auto; }
+.composer-select-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.composer-select-trigger > svg { flex: 0 0 auto; transition: transform .15s ease; }
+.composer-select-trigger > svg.open { transform: rotate(180deg); }
+.composer-select-menu { position: absolute; z-index: 18; bottom: calc(100% + 8px); left: 0; width: min(310px, calc(100vw - 36px)); max-height: min(320px, 50vh); padding: 5px; overflow-y: auto; border: 1px solid var(--border); border-radius: 7px; background: var(--surface); box-shadow: var(--shadow-lg); }
+.composer-select-menu > button { display: grid; grid-template-columns: 22px minmax(0, 1fr) 18px; width: 100%; min-height: 42px; align-items: center; gap: 6px; padding: 5px 7px; border: 0; border-radius: 5px; background: transparent; color: var(--text); cursor: pointer; text-align: left; }
+.composer-select-menu > button:hover:not(:disabled), .composer-select-menu > button[aria-checked="true"] { background: var(--surface-hover); }
+.composer-select-menu > button:disabled { cursor: default; opacity: .46; }
+.composer-option-copy { display: flex; min-width: 0; flex-direction: column; gap: 1px; }
+.composer-option-copy strong, .composer-option-copy small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.composer-option-copy strong { font-size: 12px; font-weight: 600; }
+.composer-option-copy small { color: var(--text-subtle); font-size: 10px; }
 .context-usage-indicator { position: relative; flex: 0 0 38px; width: 38px; height: 38px; --usage-ring-color: var(--primary); --usage-track: #dfe9e5; }
 .context-usage-indicator.warning { --usage-ring-color: var(--warning); }
 .context-usage-indicator.danger { --usage-ring-color: var(--danger-strong); }
@@ -512,6 +565,21 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
 .pending-file .icon-button { width: 28px; height: 28px; }
 .attachment-error { margin: 8px 10px 0; padding: 7px 9px; border: 1px solid #e2b8b2; border-radius: 5px; background: #fff4f2; color: var(--danger-text); font-size: 12px; }
 
+.approval-wrap { padding-top: 8px; }
+.approval-panel { width: min(100%, 880px); margin: 0 auto; overflow: hidden; border: 1px solid var(--warning-border); border-radius: 8px; background: var(--surface); box-shadow: var(--shadow-md); }
+.approval-strip { display: flex; min-height: 36px; align-items: center; gap: 8px; padding: 0 14px; background: var(--warning-soft); color: var(--warning-text); font-size: 12px; font-weight: 600; }
+.approval-strip > span { width: 8px; height: 8px; border-radius: 50%; background: var(--warning); }
+.approval-body { display: flex; max-height: 190px; flex-direction: column; gap: 7px; padding: 12px 14px; overflow-y: auto; outline: none; }
+.approval-body:focus-visible { box-shadow: inset 0 0 0 2px var(--primary-tint); }
+.approval-body > strong { color: var(--text-strong); font-size: 14px; line-height: 1.5; }
+.approval-operation { color: var(--text-muted); font-size: 12px; }
+.approval-arguments { display: grid; gap: 7px; margin: 2px 0 0; }
+.approval-arguments > div { display: grid; grid-template-columns: 92px minmax(0, 1fr); gap: 8px; align-items: start; }
+.approval-arguments dt { color: var(--text-subtle); font-size: 11px; }
+.approval-arguments dd { margin: 0; overflow-wrap: anywhere; color: var(--text); font-family: "Cascadia Mono", Consolas, monospace; font-size: 12px; line-height: 1.5; white-space: pre-wrap; }
+.approval-actions { display: flex; justify-content: flex-end; gap: 8px; padding: 0 14px 13px; }
+.approval-reject:hover:not(:disabled) { border-color: var(--danger-border); background: var(--danger-soft); color: var(--danger-text); }
+
 .dialog-overlay { position: fixed; inset: 0; z-index: 20; background: var(--overlay-color); }
 .mobile-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 21; width: min(86vw, 300px); padding: 0; border: 0; background: var(--surface-muted); box-shadow: 12px 0 40px rgba(20, 31, 27, .18); }
 .sidebar-close { position: absolute; z-index: 2; top: 12px; right: 10px; }
@@ -525,6 +593,8 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
 :root[data-theme="dark"] .theme-control { border-color: var(--border-input); background: var(--code-body-bg); }
 :root[data-theme="dark"] .connection-state { border-color: var(--border-input); background: var(--surface-2); color: var(--text-muted); }
 :root[data-theme="dark"] .new-chat-button { border-color: var(--border-strong); background: var(--surface-2); color: var(--text); }
+:root[data-theme="dark"] .add-workspace-button:hover,
+:root[data-theme="dark"] .workspace-header-action:hover:not(:disabled) { background: var(--surface-hover); }
 :root[data-theme="dark"] .scroll-latest { border-color: var(--border-strong); background: var(--surface-2); color: var(--primary); }
 :root[data-theme="dark"] .composer { background: var(--surface-2); }
 :root[data-theme="dark"] .topbar { border-color: var(--border-soft); background: rgba(23, 28, 26, .97); }
@@ -591,6 +661,8 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
 :root[data-theme="dark"] .session-menu { box-shadow: 0 8px 20px rgba(0, 0, 0, .28); }
 :root[data-theme="dark"] .delete-session-dialog { box-shadow: var(--shadow-lg); }
 :root[data-theme="dark"] .delete-session-dialog p { color: var(--text-faint); }
+:root[data-theme="dark"] .workspace-dialog input { border-color: var(--border-input); background: var(--surface-2); }
+:root[data-theme="dark"] .risk-acknowledgement { border-color: var(--warning-border); background: var(--warning-soft); color: var(--warning-text); }
 
 @media (max-width: 760px) {
   .app-shell { grid-template-columns: minmax(0, 1fr); }
@@ -618,6 +690,13 @@ button, .icon-button, .send-button, .new-chat-button, .session-row, .session-men
   .user-message-label { text-align: right; }
   .message-body { max-width: 100%; }
   .composer-wrap { padding: 0 10px 10px; }
+  .composer-actions { gap: 4px; padding-inline: 7px; }
+  .composer-select-trigger { width: 40px; padding: 0 4px; justify-content: center; }
+  .composer-select-label { display: none; }
+  .composer-select-menu { position: fixed; right: 18px; bottom: 64px; left: 18px; width: auto; }
+  .approval-wrap { padding-top: 6px; }
+  .approval-body { max-height: min(190px, 28vh); }
+  .approval-arguments > div { grid-template-columns: 76px minmax(0, 1fr); }
   .speech-toast { top: 9px; left: 50%; }
   .composer-hint { display: none; }
   .send-button { min-width: 38px; width: 38px; padding: 0; }

--- a/frontend/chat/src/types.ts
+++ b/frontend/chat/src/types.ts
@@ -9,6 +9,7 @@ export interface Workspace {
   title: string;
   created_at: string;
   updated_at: string;
+  pinned_at?: string | null;
   valid: boolean;
 }
 
@@ -130,6 +131,8 @@ export interface SessionSummary {
   title?: string;
   created_at: string;
   updated_at: string;
+  last_activity_at?: string;
+  pinned_at?: string | null;
   message_count: number;
   first_message_content: string;
   workspace_id?: string | null;

--- a/frontend/chat/src/types.ts
+++ b/frontend/chat/src/types.ts
@@ -1,6 +1,43 @@
 export type ConnectionStatus = "connecting" | "connected" | "reconnecting" | "offline";
 export type ToolStatus = "running" | "completed" | "error" | "interrupted";
 export type ThinkingStatus = "running" | "completed" | "interrupted";
+export type SandboxMode = "read-only" | "workspace-write" | "danger-full-access";
+
+export interface Workspace {
+  id: string;
+  canonical_path: string;
+  title: string;
+  created_at: string;
+  updated_at: string;
+  valid: boolean;
+}
+
+export interface SandboxSnapshot {
+  session_id: string;
+  workspace_id: string | null;
+  cwd_snapshot?: string | null;
+  workspace_title?: string | null;
+  workspace_path?: string | null;
+  workspace_valid: boolean;
+  sandbox_mode: SandboxMode;
+  backend: string;
+  capability: "partial" | string;
+}
+
+export interface ApprovalRequest {
+  id: string;
+  session_id: string;
+  turn_id: string;
+  call_id: string;
+  tool_name: string;
+  operation: string;
+  arguments: Record<string, unknown>;
+  reason: string;
+  requested_mode: SandboxMode;
+  fingerprint: string;
+  state: "pending";
+  created_at: string;
+}
 
 export interface ToolActivity {
   callId: string;
@@ -95,6 +132,12 @@ export interface SessionSummary {
   updated_at: string;
   message_count: number;
   first_message_content: string;
+  workspace_id?: string | null;
+  cwd_snapshot?: string | null;
+  workspace_title?: string | null;
+  workspace_path?: string | null;
+  workspace_valid?: boolean;
+  sandbox_mode?: SandboxMode;
 }
 
 export interface MessageRow {
@@ -186,6 +229,9 @@ export type ChatFrame =
   | { type: "session.created"; request_id: string; session_id: string }
   | { type: "session.updated"; session: SessionSummary }
   | { type: "session.subscribed"; request_id: string; session_id: string }
+  | { type: "sandbox.updated"; request_id: string; sandbox: SandboxSnapshot }
+  | { type: "approval.requested"; session_id: string; approval: ApprovalRequest }
+  | { type: "approval.resolved"; request_id: string; session_id: string; approval_id: string; decision: "allowed-once" | "rejected" }
   | { type: "turn.snapshot"; session_id: string; turn_id: string; request_id: string; user_message: string; user_media: string[]; content: string; thinking: string; tools: Array<{ call_id: string; name: string; status: ToolStatus | string; arguments: unknown; result_preview: string }>; started_at?: string; status: "running" }
   | { type: "turn.queued"; request_id: string; session_id: string; position: number }
   | { type: "turn.started"; request_id?: string; session_id: string; turn_id: string }

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,8 @@ Pillow>=11.0.0
 # 向量检索
 sqlite-vec>=0.1.6
 
+# Windows Restricted Token、ACL 与 Job Object 沙箱
+pywin32>=312; sys_platform == "win32"
+
 # 模型能力快照，用于在未显式配置时解析上下文窗口
 litellm>=1.95.0,<2

--- a/sandbox/__init__.py
+++ b/sandbox/__init__.py
@@ -1,0 +1,12 @@
+"""会话沙箱的策略、审批与平台运行时。"""
+
+from sandbox.approval import ApprovalCoordinator, ApprovalRequest
+from sandbox.policy import SandboxMode, SandboxPolicy, SandboxPolicyResolver
+
+__all__ = [
+    "ApprovalCoordinator",
+    "ApprovalRequest",
+    "SandboxMode",
+    "SandboxPolicy",
+    "SandboxPolicyResolver",
+]

--- a/sandbox/approval.py
+++ b/sandbox/approval.py
@@ -72,6 +72,7 @@ class ApprovalCoordinator:
         self._publisher = publisher
         self._timeout_seconds = max(1.0, float(timeout_seconds))
         self._pending: dict[str, tuple[ApprovalRequest, asyncio.Future[ApprovalState]]] = {}
+        self._resolved: dict[str, tuple[str, ApprovalState]] = {}
         self._available_sessions: set[str] = set()
         self._lock = asyncio.Lock()
 
@@ -113,7 +114,7 @@ class ApprovalCoordinator:
             call_id=call_id,
             tool_name=tool_name,
             operation=operation,
-            arguments=dict(arguments),
+            arguments=_display_arguments(tool_name, arguments),
             reason=reason,
             requested_mode=requested_mode,
             fingerprint=fingerprint,
@@ -139,7 +140,11 @@ class ApprovalCoordinator:
             self._pending[request.id] = (request, future)
             self._store.create_sandbox_approval(request.to_wire())
 
-        await self._publisher(request)
+        try:
+            await self._publisher(request)
+        except Exception as error:
+            await self._finish(request.id, "unavailable")
+            raise ApprovalUnavailable("审批请求发送失败，已拒绝越权操作") from error
         try:
             return await asyncio.wait_for(future, timeout=self._timeout_seconds)
         except asyncio.TimeoutError:
@@ -160,12 +165,22 @@ class ApprovalCoordinator:
         async with self._lock:
             current = self._pending.get(request_id)
             if current is None:
-                raise KeyError("审批请求不存在或已经结束")
+                resolved = self._resolved.get(request_id)
+                if resolved is None:
+                    raise KeyError("审批请求不存在或已经结束")
+                resolved_session, resolved_state = resolved
+                if resolved_session != session_id:
+                    raise PermissionError("审批请求不属于当前会话")
+                if resolved_state in ("allowed-once", "rejected"):
+                    return resolved_state
+                raise KeyError("审批请求已经失效")
             request, _ = current
             if request.session_id != session_id:
                 raise PermissionError("审批请求不属于当前会话")
-        await self._finish(request_id, decision)
-        return decision
+        outcome = await self._finish(request_id, decision)
+        if outcome in ("allowed-once", "rejected"):
+            return outcome
+        raise KeyError("审批请求已经失效")
 
     async def pending_for_session(self, session_id: str) -> list[ApprovalRequest]:
         async with self._lock:
@@ -192,16 +207,23 @@ class ApprovalCoordinator:
         for request_id in request_ids:
             await self._finish(request_id, "unavailable")
 
-    async def _finish(self, request_id: str, state: ApprovalState) -> None:
+    async def _finish(
+        self,
+        request_id: str,
+        state: ApprovalState,
+    ) -> ApprovalState | None:
         async with self._lock:
             current = self._pending.pop(request_id, None)
             if current is None:
-                return
-            _, future = current
+                resolved = self._resolved.get(request_id)
+                return resolved[1] if resolved is not None else None
+            request, future = current
             decided_at = datetime.now(tz=_LOCAL_TZ).isoformat()
             self._store.resolve_sandbox_approval(request_id, state, decided_at)
+            self._resolved[request_id] = (request.session_id, state)
             if not future.done():
                 future.set_result(state)
+            return state
 
 
 def operation_fingerprint(
@@ -223,6 +245,30 @@ def operation_fingerprint(
         default=str,
     )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _display_arguments(
+    tool_name: str,
+    arguments: dict[str, object],
+) -> dict[str, object]:
+    """审批只展示执行边界，不把待写正文复制到 UI 和审计表。"""
+
+    if tool_name == "write_file":
+        content = str(arguments.get("content") or "")
+        return {
+            "path": str(arguments.get("path") or ""),
+            "content_length": len(content),
+        }
+    if tool_name == "edit_file":
+        old_text = str(arguments.get("old_text") or "")
+        new_text = str(arguments.get("new_text") or "")
+        return {
+            "path": str(arguments.get("path") or ""),
+            "replace_all": bool(arguments.get("replace_all", False)),
+            "old_text_length": len(old_text),
+            "new_text_length": len(new_text),
+        }
+    return dict(arguments)
 
 
 __all__ = [

--- a/sandbox/approval.py
+++ b/sandbox/approval.py
@@ -1,0 +1,234 @@
+"""单次越权审批的并发状态机。"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Literal, Protocol
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+from sandbox.errors import ApprovalUnavailable, SandboxAccessDenied
+
+ApprovalState = Literal[
+    "pending",
+    "allowed-once",
+    "rejected",
+    "cancelled",
+    "unavailable",
+]
+ApprovalDecision = Literal["allowed-once", "rejected"]
+
+_LOCAL_TZ = ZoneInfo("Asia/Shanghai")
+
+
+class ApprovalAuditStore(Protocol):
+    def create_sandbox_approval(self, request: dict[str, object]) -> None: ...
+    def resolve_sandbox_approval(
+        self,
+        request_id: str,
+        state: str,
+        decided_at: str,
+    ) -> bool: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalRequest:
+    id: str
+    session_id: str
+    turn_id: str
+    call_id: str
+    tool_name: str
+    operation: str
+    arguments: dict[str, object]
+    reason: str
+    requested_mode: str
+    fingerprint: str
+    state: ApprovalState
+    created_at: str
+
+    def to_wire(self) -> dict[str, object]:
+        return asdict(self)
+
+
+ApprovalPublisher = Callable[[ApprovalRequest], Awaitable[None]]
+
+
+class ApprovalCoordinator:
+    """拥有 pending Future、幂等决议、可用性和取消边界。"""
+
+    def __init__(
+        self,
+        store: ApprovalAuditStore,
+        *,
+        publisher: ApprovalPublisher | None = None,
+        timeout_seconds: float = 300.0,
+    ) -> None:
+        self._store = store
+        self._publisher = publisher
+        self._timeout_seconds = max(1.0, float(timeout_seconds))
+        self._pending: dict[str, tuple[ApprovalRequest, asyncio.Future[ApprovalState]]] = {}
+        self._available_sessions: set[str] = set()
+        self._lock = asyncio.Lock()
+
+    def set_publisher(self, publisher: ApprovalPublisher) -> None:
+        self._publisher = publisher
+
+    async def set_session_available(self, session_id: str, available: bool) -> None:
+        async with self._lock:
+            if available:
+                self._available_sessions.add(session_id)
+                return
+            self._available_sessions.discard(session_id)
+            pending_ids = [
+                request_id
+                for request_id, (request, _) in self._pending.items()
+                if request.session_id == session_id
+            ]
+        for request_id in pending_ids:
+            await self._finish(request_id, "unavailable")
+
+    async def request(
+        self,
+        *,
+        session_id: str,
+        turn_id: str,
+        call_id: str,
+        tool_name: str,
+        operation: str,
+        arguments: dict[str, object],
+        reason: str,
+        requested_mode: str = "danger-full-access",
+    ) -> ApprovalState:
+        fingerprint = operation_fingerprint(tool_name, arguments, requested_mode)
+        now = datetime.now(tz=_LOCAL_TZ).isoformat()
+        request = ApprovalRequest(
+            id=uuid4().hex,
+            session_id=session_id,
+            turn_id=turn_id,
+            call_id=call_id,
+            tool_name=tool_name,
+            operation=operation,
+            arguments=dict(arguments),
+            reason=reason,
+            requested_mode=requested_mode,
+            fingerprint=fingerprint,
+            state="pending",
+            created_at=now,
+        )
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[ApprovalState] = loop.create_future()
+        async with self._lock:
+            if session_id not in self._available_sessions or self._publisher is None:
+                self._store.create_sandbox_approval(
+                    {**request.to_wire(), "state": "unavailable"}
+                )
+                raise ApprovalUnavailable("当前没有可用的审批界面，已拒绝越权操作")
+            duplicate = any(
+                current.session_id == session_id
+                and current.turn_id == turn_id
+                and current.call_id == call_id
+                for current, _ in self._pending.values()
+            )
+            if duplicate:
+                raise SandboxAccessDenied("同一工具调用已经存在待处理审批")
+            self._pending[request.id] = (request, future)
+            self._store.create_sandbox_approval(request.to_wire())
+
+        await self._publisher(request)
+        try:
+            return await asyncio.wait_for(future, timeout=self._timeout_seconds)
+        except asyncio.TimeoutError:
+            await self._finish(request.id, "cancelled")
+            return "cancelled"
+        except asyncio.CancelledError:
+            await self._finish(request.id, "cancelled")
+            raise
+
+    async def decide(
+        self,
+        request_id: str,
+        session_id: str,
+        decision: ApprovalDecision,
+    ) -> ApprovalState:
+        if decision not in ("allowed-once", "rejected"):
+            raise ValueError("审批结果只能是 allowed-once 或 rejected")
+        async with self._lock:
+            current = self._pending.get(request_id)
+            if current is None:
+                raise KeyError("审批请求不存在或已经结束")
+            request, _ = current
+            if request.session_id != session_id:
+                raise PermissionError("审批请求不属于当前会话")
+        await self._finish(request_id, decision)
+        return decision
+
+    async def pending_for_session(self, session_id: str) -> list[ApprovalRequest]:
+        async with self._lock:
+            return [
+                request
+                for request, _ in self._pending.values()
+                if request.session_id == session_id
+            ]
+
+    async def cancel_session(self, session_id: str) -> None:
+        async with self._lock:
+            request_ids = [
+                request_id
+                for request_id, (request, _) in self._pending.items()
+                if request.session_id == session_id
+            ]
+        for request_id in request_ids:
+            await self._finish(request_id, "cancelled")
+
+    async def close(self) -> None:
+        async with self._lock:
+            request_ids = list(self._pending)
+            self._available_sessions.clear()
+        for request_id in request_ids:
+            await self._finish(request_id, "unavailable")
+
+    async def _finish(self, request_id: str, state: ApprovalState) -> None:
+        async with self._lock:
+            current = self._pending.pop(request_id, None)
+            if current is None:
+                return
+            _, future = current
+            decided_at = datetime.now(tz=_LOCAL_TZ).isoformat()
+            self._store.resolve_sandbox_approval(request_id, state, decided_at)
+            if not future.done():
+                future.set_result(state)
+
+
+def operation_fingerprint(
+    tool_name: str,
+    arguments: dict[str, object],
+    requested_mode: str,
+) -> str:
+    """稳定绑定工具名、规范化参数和本次申请的执行模式。"""
+
+    payload = json.dumps(
+        {
+            "tool": str(tool_name),
+            "arguments": arguments,
+            "requested_mode": str(requested_mode),
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "ApprovalCoordinator",
+    "ApprovalDecision",
+    "ApprovalRequest",
+    "ApprovalState",
+    "operation_fingerprint",
+]

--- a/sandbox/errors.py
+++ b/sandbox/errors.py
@@ -1,0 +1,27 @@
+"""沙箱领域错误。"""
+
+from __future__ import annotations
+
+
+class SandboxError(RuntimeError):
+    """沙箱无法安全完成请求。"""
+
+
+class SandboxAccessDenied(SandboxError):
+    """当前会话策略拒绝执行。"""
+
+
+class SandboxUnavailable(SandboxError):
+    """当前平台或运行时无法提供声明的隔离能力。"""
+
+
+class ApprovalUnavailable(SandboxAccessDenied):
+    """越权请求没有可用的用户审批界面。"""
+
+
+__all__ = [
+    "ApprovalUnavailable",
+    "SandboxAccessDenied",
+    "SandboxError",
+    "SandboxUnavailable",
+]

--- a/sandbox/filesystem.py
+++ b/sandbox/filesystem.py
@@ -1,0 +1,77 @@
+"""把主进程文件写操作转交给受限 helper。"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from sandbox.errors import SandboxError
+from sandbox.policy import SandboxMode, SandboxPolicyResolver
+from sandbox.runtime import SandboxProcessRuntime
+
+
+class FilesystemMutationBroker:
+    """序列化一次写请求，并通过统一 Runtime 启动无状态 helper。"""
+
+    def __init__(
+        self,
+        resolver: SandboxPolicyResolver,
+        runtime: SandboxProcessRuntime,
+    ) -> None:
+        self._resolver = resolver
+        self._runtime = runtime
+        self._worker = Path(__file__).with_name("filesystem_worker.py").resolve()
+
+    async def execute(
+        self,
+        *,
+        session_key: str,
+        operation: str,
+        arguments: dict[str, Any],
+        execution_mode: SandboxMode | None = None,
+    ) -> str:
+        policy = self._resolver.resolve(session_key)
+        raw_path = str(arguments.get("path") or "")
+        target = Path(raw_path).expanduser()
+        if not target.is_absolute():
+            target = policy.cwd / target
+        target = target.resolve()
+        payload = {
+            **arguments,
+            "operation": operation,
+            "path": str(target),
+            "display_path": raw_path,
+        }
+        request_path = policy.temp_dir / f"file-request-{uuid4().hex}.json"
+        await asyncio.to_thread(
+            request_path.write_text,
+            json.dumps(payload, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        try:
+            result = await self._runtime.run(
+                policy,
+                [sys.executable, str(self._worker), str(request_path)],
+                cwd=policy.cwd,
+                timeout=60.0,
+                execution_mode=execution_mode,
+            )
+        finally:
+            request_path.unlink(missing_ok=True)
+        stdout = result.stdout.decode("utf-8", errors="replace").strip()
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        try:
+            response = json.loads(stdout.splitlines()[-1])
+        except (json.JSONDecodeError, IndexError) as error:
+            detail = stderr or stdout or f"exit code {result.exit_code}"
+            raise SandboxError(f"文件 helper 返回无效结果：{detail}") from error
+        if not response.get("ok"):
+            raise SandboxError(str(response.get("error") or stderr or "文件操作失败"))
+        return str(response.get("result") or "")
+
+
+__all__ = ["FilesystemMutationBroker"]

--- a/sandbox/filesystem_worker.py
+++ b/sandbox/filesystem_worker.py
@@ -1,0 +1,102 @@
+"""在沙箱子进程内执行单个文件写操作。"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import sys
+from pathlib import Path
+
+
+def _write_file(payload: dict[str, object]) -> str:
+    path = Path(str(payload["path"]))
+    content = str(payload.get("content") or "")
+    if path.exists() and path.is_dir():
+        return f"写入文件失败：目标路径是目录：{payload.get('display_path', path)}"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return f"已写入 {len(content)} 字节到 {payload.get('display_path', path)}"
+
+
+def _edit_file(payload: dict[str, object]) -> str:
+    path = Path(str(payload["path"]))
+    display_path = str(payload.get("display_path") or path)
+    if not path.exists():
+        return f"错误：文件不存在：{display_path}"
+    raw_content = path.read_bytes().decode("utf-8")
+    has_bom = raw_content.startswith("\ufeff")
+    content = raw_content[1:] if has_bom else raw_content
+    old_text = str(payload.get("old_text") or "")
+    new_text = str(payload.get("new_text") or "")
+    matched = old_text
+    replacement = new_text
+    if matched not in content and _supports_crlf_compat(content):
+        compatible = old_text.replace("\n", "\r\n")
+        if compatible in content:
+            matched = compatible
+            replacement = new_text.replace("\n", "\r\n")
+    if matched not in content:
+        return "错误：未找到 old_text，请确保与文件内容完全一致。"
+    count = content.count(matched)
+    replace_all = bool(payload.get("replace_all"))
+    if count > 1 and not replace_all:
+        return (
+            f"警告：old_text 在文件中出现了 {count} 次。"
+            "如需全部替换，设 replace_all=true；如需精确定位，请包含更多上下文。"
+        )
+    new_content = (
+        content.replace(matched, replacement)
+        if replace_all
+        else content.replace(matched, replacement, 1)
+    )
+    diff = "\n".join(
+        difflib.unified_diff(
+            content.splitlines(),
+            new_content.splitlines(),
+            fromfile=f"{display_path} (before)",
+            tofile=f"{display_path} (after)",
+            lineterm="",
+            n=2,
+        )
+    )
+    restored = ("\ufeff" if has_bom else "") + new_content
+    path.write_text(restored, encoding="utf-8", newline="")
+    replaced_count = count if replace_all else 1
+    if diff:
+        return (
+            f"已成功编辑 {display_path}（替换 {replaced_count} 处）\n\n"
+            f"```diff\n{diff}\n```"
+        )
+    return f"已成功编辑 {display_path}（替换 {replaced_count} 处）"
+
+
+def _supports_crlf_compat(text: str) -> bool:
+    if "\r\n" not in text:
+        return False
+    without_crlf = text.replace("\r\n", "")
+    return "\n" not in without_crlf and "\r" not in without_crlf
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(json.dumps({"ok": False, "error": "文件操作请求参数无效"}))
+        return 2
+    try:
+        payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+        operation = str(payload.get("operation") or "")
+        if operation == "write_file":
+            result = _write_file(payload)
+        elif operation == "edit_file":
+            result = _edit_file(payload)
+        else:
+            raise ValueError(f"不支持的文件操作：{operation}")
+        # stdout 是跨进程协议，ASCII 转义不依赖 Windows 当前控制台代码页。
+        print(json.dumps({"ok": True, "result": result}))
+        return 0
+    except Exception as error:
+        print(json.dumps({"ok": False, "error": str(error)}))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sandbox/guard.py
+++ b/sandbox/guard.py
@@ -1,0 +1,125 @@
+"""文件和 Shell 工具共用的策略与单次审批入口。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from sandbox.approval import ApprovalCoordinator
+from sandbox.errors import SandboxAccessDenied
+from sandbox.policy import SandboxMode, SandboxPolicy, SandboxPolicyResolver
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizedExecution:
+    policy: SandboxPolicy
+    mode: SandboxMode
+
+
+class SandboxGuard:
+    """只负责授权决策，不执行文件或进程操作。"""
+
+    def __init__(
+        self,
+        resolver: SandboxPolicyResolver,
+        approvals: ApprovalCoordinator,
+    ) -> None:
+        self._resolver = resolver
+        self._approvals = approvals
+
+    def policy(self, session_key: str) -> SandboxPolicy:
+        return self._resolver.resolve(session_key)
+
+    async def authorize_file_mutation(
+        self,
+        *,
+        session_key: str,
+        turn_id: str,
+        call_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        target: Path,
+        operation: str,
+    ) -> AuthorizedExecution:
+        policy = self.policy(session_key)
+        if policy.mode == "danger-full-access":
+            return AuthorizedExecution(policy, "danger-full-access")
+        if policy.mode == "workspace-write" and policy.contains_workspace_path(target):
+            return AuthorizedExecution(policy, "workspace-write")
+        reason = (
+            "当前会话为只读，文件写入需要单次授权"
+            if policy.mode == "read-only"
+            else "目标位于工作区外，写入需要单次授权"
+        )
+        return await self._request_once(
+            policy=policy,
+            session_key=session_key,
+            turn_id=turn_id,
+            call_id=call_id,
+            tool_name=tool_name,
+            operation=operation,
+            arguments=arguments,
+            reason=reason,
+        )
+
+    async def authorize_shell_retry(
+        self,
+        *,
+        policy: SandboxPolicy,
+        turn_id: str,
+        call_id: str,
+        arguments: dict[str, Any],
+    ) -> AuthorizedExecution:
+        return await self._request_once(
+            policy=policy,
+            session_key=policy.session_key,
+            turn_id=turn_id,
+            call_id=call_id,
+            tool_name="shell",
+            operation="执行完整 Shell 命令",
+            arguments=arguments,
+            reason="命令在当前写入边界内被 Windows 拒绝，可仅对这次完整命令放宽限制",
+        )
+
+    async def _request_once(
+        self,
+        *,
+        policy: SandboxPolicy,
+        session_key: str,
+        turn_id: str,
+        call_id: str,
+        tool_name: str,
+        operation: str,
+        arguments: dict[str, Any],
+        reason: str,
+    ) -> AuthorizedExecution:
+        if not turn_id or not call_id:
+            raise SandboxAccessDenied("缺少 Turn 或工具调用身份，不能申请越权授权")
+        outcome = await self._approvals.request(
+            session_id=session_key,
+            turn_id=turn_id,
+            call_id=call_id,
+            tool_name=tool_name,
+            operation=operation,
+            arguments=dict(arguments),
+            reason=reason,
+        )
+        if outcome != "allowed-once":
+            messages = {
+                "rejected": "用户拒绝了本次越权操作",
+                "cancelled": "本次越权授权已取消或超时",
+                "unavailable": "当前没有可用审批界面",
+            }
+            raise SandboxAccessDenied(messages.get(outcome, "本次越权操作未获授权"))
+        return AuthorizedExecution(policy, "danger-full-access")
+
+
+def resolve_tool_target(raw_path: str, policy: SandboxPolicy) -> Path:
+    candidate = Path(raw_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = policy.cwd / candidate
+    return candidate.resolve()
+
+
+__all__ = ["AuthorizedExecution", "SandboxGuard", "resolve_tool_target"]

--- a/sandbox/policy.py
+++ b/sandbox/policy.py
@@ -1,0 +1,152 @@
+"""按持久化会话状态解析文件副作用策略。"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Protocol, cast
+
+from sandbox.errors import SandboxAccessDenied
+
+SandboxMode = Literal["read-only", "workspace-write", "danger-full-access"]
+SANDBOX_MODES: tuple[SandboxMode, ...] = (
+    "read-only",
+    "workspace-write",
+    "danger-full-access",
+)
+
+
+class SessionPolicyStore(Protocol):
+    def get_session_sandbox(self, session_key: str) -> dict[str, object] | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxPolicy:
+    """一次工具调用使用的不可变会话策略快照。"""
+
+    session_key: str
+    mode: SandboxMode
+    workspace_id: str | None
+    workspace_path: Path | None
+    cwd: Path
+    temp_dir: Path
+    backend: str = "windows-acl"
+    capability: str = "partial"
+
+    @property
+    def workspace_available(self) -> bool:
+        return self.workspace_id is not None and self.workspace_path is not None
+
+    def contains_workspace_path(self, path: Path) -> bool:
+        if self.workspace_path is None:
+            return False
+        return _contains(self.workspace_path, path)
+
+
+class SandboxPolicyResolver:
+    """只从服务端会话关系生成策略，不接收客户端临时根目录。"""
+
+    def __init__(
+        self,
+        store: SessionPolicyStore,
+        *,
+        data_root: Path,
+        runtime_temp_root: Path,
+    ) -> None:
+        self._store = store
+        self._data_root = data_root.expanduser().resolve()
+        self._runtime_temp_root = runtime_temp_root.expanduser().resolve()
+        self._runtime_temp_root.mkdir(parents=True, exist_ok=True)
+
+    def resolve(self, session_key: str) -> SandboxPolicy:
+        snapshot = self._store.get_session_sandbox(session_key)
+        if snapshot is None:
+            raise SandboxAccessDenied(f"会话不存在：{session_key}")
+        raw_mode = str(snapshot.get("sandbox_mode") or "read-only")
+        if raw_mode not in SANDBOX_MODES:
+            raise SandboxAccessDenied(f"会话沙箱权限无效：{raw_mode}")
+
+        temp_dir = self._session_temp_dir(session_key)
+        workspace_path: Path | None = None
+        raw_path = str(snapshot.get("workspace_path") or "").strip()
+        workspace_id = str(snapshot.get("workspace_id") or "").strip() or None
+        if raw_path and workspace_id:
+            candidate = Path(raw_path).expanduser().resolve(strict=True)
+            if not candidate.is_dir():
+                raise SandboxAccessDenied(f"工作目录已失效：{candidate}")
+            self._assert_disjoint(candidate, temp_dir)
+            workspace_path = candidate
+
+        mode = cast(SandboxMode, raw_mode)
+        if mode == "workspace-write" and workspace_path is None:
+            raise SandboxAccessDenied("没有工作目录时不能使用工作区可写权限")
+        cwd = workspace_path if workspace_path is not None else temp_dir
+        return SandboxPolicy(
+            session_key=session_key,
+            mode=mode,
+            workspace_id=workspace_id,
+            workspace_path=workspace_path,
+            cwd=cwd,
+            temp_dir=temp_dir,
+        )
+
+    def close_session(self, session_key: str) -> None:
+        """只删除本次运行创建的私有临时目录。"""
+
+        import shutil
+
+        target = self._session_temp_dir(session_key, create=False)
+        if target.exists():
+            shutil.rmtree(target)
+
+    def _session_temp_dir(self, session_key: str, *, create: bool = True) -> Path:
+        import hashlib
+
+        digest = hashlib.sha256(session_key.encode("utf-8")).hexdigest()[:24]
+        target = (self._runtime_temp_root / digest).resolve()
+        target.relative_to(self._runtime_temp_root)
+        if create:
+            target.mkdir(parents=True, exist_ok=True)
+        return target
+
+    def _assert_disjoint(self, workspace: Path, temp_dir: Path) -> None:
+        if _contains(workspace, self._data_root) or _contains(self._data_root, workspace):
+            raise SandboxAccessDenied(
+                f"工作目录不能与 Bean 数据目录重叠：{workspace}"
+            )
+        if _contains(workspace, temp_dir) or _contains(temp_dir, workspace):
+            raise SandboxAccessDenied(
+                f"工作目录不能与会话临时目录重叠：{workspace}"
+            )
+
+
+def canonical_directory(path: str | Path) -> Path:
+    """按当前平台语义返回真实绝对目录。"""
+
+    resolved = Path(path).expanduser().resolve(strict=True)
+    if not resolved.is_dir():
+        raise ValueError(f"路径不是目录：{resolved}")
+    return resolved
+
+
+def canonical_path_key(path: str | Path) -> str:
+    return os.path.normcase(str(canonical_directory(path)))
+
+
+def _contains(root: Path, candidate: Path) -> bool:
+    try:
+        candidate.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+__all__ = [
+    "SANDBOX_MODES",
+    "SandboxMode",
+    "SandboxPolicy",
+    "SandboxPolicyResolver",
+    "canonical_directory",
+    "canonical_path_key",
+]

--- a/sandbox/policy.py
+++ b/sandbox/policy.py
@@ -100,6 +100,21 @@ class SandboxPolicyResolver:
         if target.exists():
             shutil.rmtree(target)
 
+    def close(self) -> None:
+        """应用退出时清理本进程独占的临时根。"""
+
+        import shutil
+
+        if self._runtime_temp_root.exists():
+            shutil.rmtree(self._runtime_temp_root)
+
+    def validate_workspace(self, path: str | Path) -> Path:
+        """注册前验证真实目录不会覆盖 Bean 数据或运行时内部目录。"""
+
+        workspace = canonical_directory(path)
+        self._assert_disjoint(workspace, self._runtime_temp_root)
+        return workspace
+
     def _session_temp_dir(self, session_key: str, *, create: bool = True) -> Path:
         import hashlib
 

--- a/sandbox/runtime.py
+++ b/sandbox/runtime.py
@@ -1,0 +1,165 @@
+"""平台无关的会话子进程运行入口。"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import uuid4
+
+from sandbox.errors import SandboxUnavailable
+from sandbox.policy import SandboxMode, SandboxPolicy, SandboxPolicyResolver
+from sandbox.windows import (
+    WindowsAclProvider,
+    WindowsProcessLauncher,
+    temp_write_sid,
+    workspace_write_sid,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxRunResult:
+    stdout: bytes
+    stderr: bytes
+    exit_code: int
+    interrupted: bool
+
+
+class SandboxProcessRuntime:
+    """Windows-first Runtime；受限模式在非 Windows 上始终 fail closed。"""
+
+    def __init__(
+        self,
+        resolver: SandboxPolicyResolver,
+        *,
+        acl: WindowsAclProvider | None = None,
+        launcher: WindowsProcessLauncher | None = None,
+    ) -> None:
+        self._resolver = resolver
+        self._acl = acl or WindowsAclProvider()
+        self._launcher = launcher or WindowsProcessLauncher()
+        self._prepared_temps: dict[str, tuple[Path, str]] = {}
+        self._prepare_locks: dict[str, asyncio.Lock] = {}
+        self._closed = False
+
+    async def run(
+        self,
+        policy: SandboxPolicy,
+        argv: list[str],
+        *,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+        timeout: float = 60.0,
+        execution_mode: SandboxMode | None = None,
+    ) -> SandboxRunResult:
+        if self._closed:
+            raise SandboxUnavailable("沙箱 Runtime 已关闭")
+        mode = execution_mode or policy.mode
+        actual_cwd = (cwd or policy.cwd).expanduser().resolve(strict=True)
+        if not actual_cwd.is_dir():
+            raise SandboxUnavailable(f"子进程 cwd 不是目录：{actual_cwd}")
+        workspace_sid: str | None = None
+        private_temp_sid: str | None = None
+        if mode != "danger-full-access":
+            if os.name != "nt":
+                raise SandboxUnavailable("当前平台不支持 Windows ACL 沙箱")
+            if mode == "workspace-write":
+                if policy.workspace_path is None:
+                    raise SandboxUnavailable("工作区可写模式缺少工作目录")
+                workspace_sid, private_temp_sid = await self._prepare_workspace(policy)
+
+        process_env = os.environ.copy()
+        process_env.update(env or {})
+        process_env["TMP"] = str(policy.temp_dir)
+        process_env["TEMP"] = str(policy.temp_dir)
+        result = await self._launcher.run(
+            list(argv),
+            cwd=str(actual_cwd),
+            env=process_env,
+            timeout=timeout,
+            mode=mode,
+            workspace_sid=workspace_sid,
+            temp_sid=private_temp_sid,
+        )
+        return SandboxRunResult(
+            stdout=result.stdout,
+            stderr=result.stderr,
+            exit_code=result.exit_code,
+            interrupted=result.interrupted,
+        )
+
+    async def close_session(self, session_key: str) -> None:
+        prepared = self._prepared_temps.pop(session_key, None)
+        if prepared is not None:
+            path, _ = prepared
+            await asyncio.to_thread(self._acl.revoke_temp, path)
+        self._prepare_locks.pop(session_key, None)
+        await asyncio.to_thread(self._resolver.close_session, session_key)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        failures: list[BaseException] = []
+        for session_key in list(self._prepared_temps):
+            try:
+                await self.close_session(session_key)
+            except BaseException as error:
+                failures.append(error)
+        try:
+            await asyncio.to_thread(self._acl.close)
+        except BaseException as error:
+            failures.append(error)
+        try:
+            await asyncio.to_thread(self._resolver.close)
+        except BaseException as error:
+            failures.append(error)
+        if failures:
+            raise SandboxUnavailable(f"沙箱清理失败：{failures[0]}") from failures[0]
+
+    async def _prepare_workspace(self, policy: SandboxPolicy) -> tuple[str, str]:
+        lock = self._prepare_locks.setdefault(policy.session_key, asyncio.Lock())
+        async with lock:
+            workspace_sid = workspace_write_sid(policy.workspace_path)
+            await asyncio.to_thread(
+                self._acl.grant_workspace,
+                policy.workspace_path,
+                workspace_sid,
+            )
+            prepared = self._prepared_temps.get(policy.session_key)
+            if prepared is not None and prepared[0] == policy.temp_dir:
+                return workspace_sid, prepared[1]
+            private_temp_sid = temp_write_sid(policy.temp_dir)
+            # DACL 修改可能递归传播，放在线程池中避免阻塞 WebSocket 事件循环。
+            try:
+                await asyncio.to_thread(
+                    self._acl.grant_temp,
+                    policy.temp_dir,
+                    private_temp_sid,
+                )
+            except Exception:
+                # workspace ACE 是跨会话复用缓存，失败时保持；temp ACE 必须可撤销。
+                await asyncio.to_thread(self._acl.revoke_temp, policy.temp_dir)
+                raise
+            self._prepared_temps[policy.session_key] = (
+                policy.temp_dir,
+                private_temp_sid,
+            )
+            return workspace_sid, private_temp_sid
+
+
+def create_runtime_temp_root() -> Path:
+    """每次进程使用全新的系统 temp 根，旧残留不会获得新会话能力。"""
+
+    root = (
+        Path(tempfile.gettempdir())
+        / "beanagent"
+        / f"runtime-{uuid4().hex}"
+    ).resolve()
+    root.mkdir(parents=True, exist_ok=False)
+    return root
+
+
+__all__ = ["SandboxProcessRuntime", "SandboxRunResult", "create_runtime_temp_root"]

--- a/sandbox/shell.py
+++ b/sandbox/shell.py
@@ -1,0 +1,44 @@
+"""把完整 Shell 命令转交给已受限的轻量 worker。"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+from sandbox.policy import SandboxMode, SandboxPolicy
+from sandbox.runtime import SandboxProcessRuntime, SandboxRunResult
+
+
+class SandboxShellBroker:
+    """用请求文件绕开 cmd.exe 与通用 Windows argv 转义的不兼容。"""
+
+    def __init__(self, runtime: SandboxProcessRuntime) -> None:
+        self._runtime = runtime
+        self._worker = Path(__file__).with_name("shell_worker.py").resolve()
+
+    async def execute(
+        self,
+        policy: SandboxPolicy,
+        command: str,
+        *,
+        cwd: Path,
+        timeout: float,
+        execution_mode: SandboxMode | None = None,
+    ) -> SandboxRunResult:
+        request_path = policy.temp_dir / f"shell-request-{uuid4().hex}.txt"
+        await asyncio.to_thread(request_path.write_text, command, encoding="utf-8")
+        try:
+            return await self._runtime.run(
+                policy,
+                [sys.executable, str(self._worker), str(request_path)],
+                cwd=cwd,
+                timeout=timeout,
+                execution_mode=execution_mode,
+            )
+        finally:
+            request_path.unlink(missing_ok=True)
+
+
+__all__ = ["SandboxShellBroker"]

--- a/sandbox/shell_worker.py
+++ b/sandbox/shell_worker.py
@@ -1,0 +1,24 @@
+"""在 Restricted Token 内调用当前平台的系统 Shell。"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("bean-sandbox-shell: 请求参数无效", file=sys.stderr)
+        return 127
+    try:
+        command = Path(sys.argv[1]).read_text(encoding="utf-8")
+        # worker 已处于受限 Token 和 Job 中，系统 Shell 及其后代会继承两者。
+        return int(subprocess.run(command, shell=True, check=False).returncode)
+    except Exception as error:
+        print(f"bean-sandbox-shell: {error}", file=sys.stderr)
+        return 127
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sandbox/windows/__init__.py
+++ b/sandbox/windows/__init__.py
@@ -1,0 +1,11 @@
+"""Windows ACL 沙箱平台实现。"""
+
+from sandbox.windows.acl import WindowsAclProvider, temp_write_sid, workspace_write_sid
+from sandbox.windows.process import WindowsProcessLauncher
+
+__all__ = [
+    "WindowsAclProvider",
+    "WindowsProcessLauncher",
+    "temp_write_sid",
+    "workspace_write_sid",
+]

--- a/sandbox/windows/acl.py
+++ b/sandbox/windows/acl.py
@@ -1,0 +1,252 @@
+"""Windows 目录能力 SID 与 DACL 管理。"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from sandbox.errors import SandboxUnavailable
+
+_GRANT_MASK = 0x00110156
+_FILE_ALL_ACCESS = 0x001F01FF
+_INHERIT_FLAGS = 0x1 | 0x2
+
+
+def workspace_write_sid(workspace: str | Path) -> str:
+    return _sid_from_digest(str(Path(workspace).resolve()).encode("utf-8"), temp=False)
+
+
+def temp_write_sid(temp_dir: str | Path) -> str:
+    payload = b"temp\0" + str(Path(temp_dir).resolve()).encode("utf-8")
+    return _sid_from_digest(payload, temp=True)
+
+
+def _sid_from_digest(payload: bytes, *, temp: bool) -> str:
+    digest = hashlib.sha256(payload).digest()
+    limit = 2**30 - 1
+    first = int.from_bytes(digest[:4], "little") % limit + 1
+    second = int.from_bytes(digest[4:8], "little") % limit + 1
+    suffix = "-1" if temp else ""
+    return f"S-1-4-{first}-{second}{suffix}"
+
+
+class WindowsAclProvider:
+    """串行维护 standing workspace ACE 和可撤销 temp ACE。"""
+
+    def __init__(self) -> None:
+        self._workspace_grants: set[tuple[str, str]] = set()
+        self._temp_grants: dict[str, str] = {}
+        self._lock = threading.RLock()
+
+    def grant_workspace(self, path: Path, sid_text: str) -> None:
+        key = (os.path.normcase(str(path.resolve())), sid_text)
+        with self._lock:
+            if key in self._workspace_grants:
+                return
+            self._grant(path, sid_text)
+            self._workspace_grants.add(key)
+
+    def grant_temp(self, path: Path, sid_text: str) -> None:
+        key = os.path.normcase(str(path.resolve()))
+        with self._lock:
+            if self._temp_grants.get(key) == sid_text:
+                return
+            self._grant(path, sid_text)
+            self._temp_grants[key] = sid_text
+
+    def revoke_temp(self, path: Path) -> None:
+        key = os.path.normcase(str(path.resolve()))
+        with self._lock:
+            sid_text = self._temp_grants.pop(key, None)
+            if sid_text is not None and path.exists():
+                self._revoke(path, sid_text)
+
+    def close(self) -> None:
+        failures: list[Exception] = []
+        with self._lock:
+            grants = list(self._temp_grants.items())
+        for raw_path, _ in grants:
+            try:
+                self.revoke_temp(Path(raw_path))
+            except Exception as error:
+                failures.append(error)
+        if failures:
+            raise SandboxUnavailable(
+                f"撤销会话临时目录 ACL 失败：{failures[0]}"
+            ) from failures[0]
+
+    def _grant(self, path: Path, sid_text: str) -> None:
+        win32security, _ = _security_modules()
+        target = path.resolve(strict=True)
+        if not target.is_dir():
+            raise SandboxUnavailable(f"ACL 目标不是目录：{target}")
+        sid = win32security.ConvertStringSidToSid(sid_text)
+        with _path_lock(target):
+            descriptor = win32security.GetNamedSecurityInfo(
+                str(target),
+                win32security.SE_FILE_OBJECT,
+                win32security.OWNER_SECURITY_INFORMATION
+                | win32security.DACL_SECURITY_INFORMATION,
+            )
+            current_sid = _assert_owned_by_current_user(
+                descriptor, target, win32security
+            )
+            dacl = descriptor.GetSecurityDescriptorDacl()
+            if dacl is None:
+                dacl = win32security.ACL()
+            if _has_capability_ace(dacl, sid_text):
+                return
+            # 所有者隐式访问在部分继承 ACL 上不会形成普通 Token 的显式写 ACE；
+            # Restricted Token 的两阶段检查需要先保留调用用户原本拥有的访问。
+            owner_rights_sid = win32security.ConvertStringSidToSid("S-1-3-4")
+            if (
+                not _has_full_access_ace(dacl, str(current_sid))
+                and _has_full_access_ace(dacl, str(owner_rights_sid))
+            ):
+                dacl.AddAccessAllowedAceEx(
+                    win32security.ACL_REVISION_DS,
+                    _INHERIT_FLAGS,
+                    _FILE_ALL_ACCESS,
+                    current_sid,
+                )
+            dacl.AddAccessAllowedAceEx(
+                win32security.ACL_REVISION_DS,
+                _INHERIT_FLAGS,
+                _GRANT_MASK,
+                sid,
+            )
+            win32security.SetNamedSecurityInfo(
+                str(target),
+                win32security.SE_FILE_OBJECT,
+                win32security.DACL_SECURITY_INFORMATION,
+                None,
+                None,
+                dacl,
+                None,
+            )
+
+    def _revoke(self, path: Path, sid_text: str) -> None:
+        win32security, _ = _security_modules()
+        target = path.resolve(strict=True)
+        sid_indexes: list[int] = []
+        with _path_lock(target):
+            descriptor = win32security.GetNamedSecurityInfo(
+                str(target),
+                win32security.SE_FILE_OBJECT,
+                win32security.DACL_SECURITY_INFORMATION,
+            )
+            dacl = descriptor.GetSecurityDescriptorDacl()
+            if dacl is None:
+                return
+            for index in range(dacl.GetAceCount()):
+                ace = dacl.GetAce(index)
+                if len(ace) >= 3 and str(ace[2]) == sid_text:
+                    sid_indexes.append(index)
+            for index in reversed(sid_indexes):
+                dacl.DeleteAce(index)
+            if sid_indexes:
+                win32security.SetNamedSecurityInfo(
+                    str(target),
+                    win32security.SE_FILE_OBJECT,
+                    win32security.DACL_SECURITY_INFORMATION,
+                    None,
+                    None,
+                    dacl,
+                    None,
+                )
+
+
+def _has_capability_ace(dacl: object, sid_text: str) -> bool:
+    for index in range(dacl.GetAceCount()):  # type: ignore[attr-defined]
+        ace = dacl.GetAce(index)  # type: ignore[attr-defined]
+        if len(ace) < 3:
+            continue
+        header, mask, sid = ace[:3]
+        ace_type = int(header[0]) if isinstance(header, tuple) else -1
+        ace_flags = int(header[1]) if isinstance(header, tuple) else 0
+        if (
+            ace_type == 0
+            and int(mask) == _GRANT_MASK
+            and ace_flags & _INHERIT_FLAGS == _INHERIT_FLAGS
+            and str(sid) == sid_text
+        ):
+            return True
+    return False
+
+
+def _has_full_access_ace(dacl: object, sid_text: str) -> bool:
+    for index in range(dacl.GetAceCount()):  # type: ignore[attr-defined]
+        ace = dacl.GetAce(index)  # type: ignore[attr-defined]
+        if len(ace) >= 3 and int(ace[1]) == _FILE_ALL_ACCESS and str(ace[2]) == sid_text:
+            return True
+    return False
+
+
+def _assert_owned_by_current_user(
+    descriptor: object,
+    path: Path,
+    win32security: object,
+) -> object:
+    import win32api
+    import win32con
+
+    token = win32security.OpenProcessToken(  # type: ignore[attr-defined]
+        win32api.GetCurrentProcess(), win32con.TOKEN_QUERY
+    )
+    try:
+        token_user = win32security.GetTokenInformation(  # type: ignore[attr-defined]
+            token, win32security.TokenUser  # type: ignore[attr-defined]
+        )
+        current_sid = token_user[0] if isinstance(token_user, tuple) else token_user
+    finally:
+        token.Close()
+    owner_sid = descriptor.GetSecurityDescriptorOwner()  # type: ignore[attr-defined]
+    if str(owner_sid) != str(current_sid):
+        raise SandboxUnavailable(f"目录必须由当前 Windows 用户拥有：{path}")
+    return current_sid
+
+
+@contextmanager
+def _path_lock(path: Path) -> Iterator[None]:
+    """跨进程串行 DACL 的读改写，避免并发授权互相覆盖。"""
+
+    if os.name != "nt":
+        raise SandboxUnavailable("Windows ACL 沙箱仅支持 Windows")
+    import msvcrt
+
+    digest = hashlib.sha256(os.path.normcase(str(path)).encode("utf-8")).hexdigest()[:16]
+    lock_root = Path(tempfile.gettempdir()) / "beanagent-acl-locks"
+    lock_root.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_root / f"{digest}.lock"
+    with lock_path.open("a+b") as stream:
+        if stream.tell() == 0:
+            stream.write(b"\0")
+            stream.flush()
+        stream.seek(0)
+        msvcrt.locking(stream.fileno(), msvcrt.LK_LOCK, 1)
+        try:
+            yield
+        finally:
+            stream.seek(0)
+            msvcrt.locking(stream.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def _security_modules() -> tuple[object, object]:
+    if os.name != "nt":
+        raise SandboxUnavailable("Windows ACL 沙箱仅支持 Windows")
+    try:
+        import win32security
+        import pywintypes
+    except ImportError as error:
+        raise SandboxUnavailable(
+            "缺少 Windows 沙箱依赖 pywin32，已拒绝不受限执行"
+        ) from error
+    return win32security, pywintypes
+
+
+__all__ = ["WindowsAclProvider", "temp_write_sid", "workspace_write_sid"]

--- a/sandbox/windows/process.py
+++ b/sandbox/windows/process.py
@@ -1,0 +1,326 @@
+"""Restricted Token、匿名管道与 Job Object 子进程启动。"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import Literal
+
+from sandbox.errors import SandboxUnavailable
+
+_LUA_TOKEN = 0x4
+_WRITE_RESTRICTED = 0x8
+_SE_GROUP_LOGON_ID = 0xC0000000
+_ERROR_BROKEN_PIPE = 109
+_FILE_ALL_ACCESS = 0x001F01FF
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessResult:
+    stdout: bytes
+    stderr: bytes
+    exit_code: int
+    interrupted: bool
+
+
+class WindowsProcessLauncher:
+    """先挂入 kill-on-close Job，再运行受限或普通 Windows 子进程。"""
+
+    async def run(
+        self,
+        argv: list[str],
+        *,
+        cwd: str,
+        env: dict[str, str],
+        timeout: float,
+        mode: Literal["read-only", "workspace-write", "danger-full-access"],
+        workspace_sid: str | None = None,
+        temp_sid: str | None = None,
+    ) -> ProcessResult:
+        if os.name != "nt":
+            raise SandboxUnavailable("Windows 进程沙箱在当前平台不可用")
+        if not argv:
+            raise SandboxUnavailable("沙箱子进程命令不能为空")
+        token = None
+        try:
+            if mode != "danger-full-access":
+                token = _create_restricted_token(mode, workspace_sid, temp_sid)
+            process = _spawn_suspended(argv, cwd=cwd, env=env, token=token)
+        except Exception as error:
+            if isinstance(error, SandboxUnavailable):
+                raise
+            raise SandboxUnavailable(f"Windows 沙箱启动失败：{error}") from error
+        finally:
+            if token is not None:
+                token.Close()
+
+        try:
+            return await process.communicate(timeout)
+        except asyncio.CancelledError:
+            process.terminate()
+            await process.wait()
+            raise
+        finally:
+            process.close()
+
+
+class _WindowsChild:
+    def __init__(
+        self,
+        process_handle: object,
+        job_handle: object,
+        stdout_read: object,
+        stderr_read: object,
+    ) -> None:
+        self._process = process_handle
+        self._job = job_handle
+        self._stdout = stdout_read
+        self._stderr = stderr_read
+        self._closed = False
+
+    async def communicate(self, timeout: float) -> ProcessResult:
+        stdout_task = asyncio.create_task(asyncio.to_thread(_drain_pipe, self._stdout))
+        stderr_task = asyncio.create_task(asyncio.to_thread(_drain_pipe, self._stderr))
+        interrupted = False
+        try:
+            completed = await asyncio.wait_for(self.wait(), timeout=max(0.1, timeout))
+            if not completed:
+                interrupted = True
+                self.terminate()
+                await self.wait()
+            stdout, stderr = await asyncio.gather(stdout_task, stderr_task)
+        except BaseException:
+            self.terminate()
+            await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+            raise
+        return ProcessResult(
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=-1 if interrupted else _exit_code(self._process),
+            interrupted=interrupted,
+        )
+
+    async def wait(self) -> bool:
+        import win32event
+
+        status = await asyncio.to_thread(
+            win32event.WaitForSingleObject,
+            self._process,
+            win32event.INFINITE,
+        )
+        return status == win32event.WAIT_OBJECT_0
+
+    def terminate(self) -> None:
+        import win32job
+
+        try:
+            win32job.TerminateJobObject(self._job, 1)
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for handle in (self._stdout, self._stderr, self._process, self._job):
+            try:
+                handle.Close()
+            except Exception:
+                pass
+
+
+def _create_restricted_token(
+    mode: str,
+    workspace_sid: str | None,
+    temp_sid: str | None,
+) -> object:
+    try:
+        import win32api
+        import win32con
+        import win32security
+    except ImportError as error:
+        raise SandboxUnavailable(
+            "缺少 Windows 沙箱依赖 pywin32，已拒绝不受限执行"
+        ) from error
+
+    if mode == "workspace-write" and not workspace_sid:
+        raise SandboxUnavailable("工作区可写 Token 缺少 workspace SID")
+    current = win32security.OpenProcessToken(
+        win32api.GetCurrentProcess(),
+        win32con.TOKEN_QUERY
+        | win32con.TOKEN_DUPLICATE
+        | win32con.TOKEN_ADJUST_DEFAULT
+        | win32con.TOKEN_ASSIGN_PRIMARY,
+    )
+    try:
+        groups = win32security.GetTokenInformation(current, win32security.TokenGroups)
+        logon_sid = next(
+            (sid for sid, attributes in groups if int(attributes) & _SE_GROUP_LOGON_ID == _SE_GROUP_LOGON_ID),
+            None,
+        )
+        if logon_sid is None:
+            raise SandboxUnavailable("当前 Windows Token 没有 logon SID")
+        world_sid = win32security.CreateWellKnownSid(win32security.WinWorldSid, None)
+        restricting = [(logon_sid, 0), (world_sid, 0)]
+        default_grant_sid = world_sid
+        if mode == "workspace-write":
+            workspace = win32security.ConvertStringSidToSid(workspace_sid)
+            restricting.append((workspace, 0))
+            default_grant_sid = workspace
+            if temp_sid:
+                private_temp = win32security.ConvertStringSidToSid(temp_sid)
+                restricting.append((private_temp, 0))
+                default_grant_sid = private_temp
+        restricted = win32security.CreateRestrictedToken(
+            current,
+            win32security.DISABLE_MAX_PRIVILEGE | _LUA_TOKEN | _WRITE_RESTRICTED,
+            [],
+            [],
+            restricting,
+        )
+    finally:
+        current.Close()
+
+    try:
+        dacl = win32security.GetTokenInformation(
+            restricted, win32security.TokenDefaultDacl
+        )
+        dacl.AddAccessAllowedAceEx(
+            win32security.ACL_REVISION_DS,
+            0,
+            _FILE_ALL_ACCESS,
+            default_grant_sid,
+        )
+        win32security.SetTokenInformation(
+            restricted, win32security.TokenDefaultDacl, dacl
+        )
+    except Exception:
+        restricted.Close()
+        raise
+    return restricted
+
+
+def _spawn_suspended(
+    argv: list[str],
+    *,
+    cwd: str,
+    env: dict[str, str],
+    token: object | None,
+) -> _WindowsChild:
+    import win32api
+    import win32con
+    import win32job
+    import win32pipe
+    import win32process
+
+    stdin_read, stdin_write = win32pipe.CreatePipe(None, 0)
+    stdout_read, stdout_write = win32pipe.CreatePipe(None, 0)
+    stderr_read, stderr_write = win32pipe.CreatePipe(None, 0)
+    child_handles = (stdin_read, stdout_write, stderr_write)
+    host_handles = (stdin_write, stdout_read, stderr_read)
+    for handle in child_handles:
+        win32api.SetHandleInformation(
+            handle, win32con.HANDLE_FLAG_INHERIT, win32con.HANDLE_FLAG_INHERIT
+        )
+    for handle in host_handles:
+        win32api.SetHandleInformation(handle, win32con.HANDLE_FLAG_INHERIT, 0)
+
+    job = win32job.CreateJobObject(None, "")
+    info = win32job.QueryInformationJobObject(
+        job, win32job.JobObjectExtendedLimitInformation
+    )
+    info["BasicLimitInformation"]["LimitFlags"] |= (
+        win32job.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    )
+    win32job.SetInformationJobObject(
+        job, win32job.JobObjectExtendedLimitInformation, info
+    )
+
+    startup = win32process.STARTUPINFO()
+    startup.dwFlags |= win32process.STARTF_USESTDHANDLES
+    startup.hStdInput = stdin_read
+    startup.hStdOutput = stdout_write
+    startup.hStdError = stderr_write
+    command_line = subprocess.list2cmdline(argv)
+    # 子进程必须先进入 kill-on-close Job，再允许执行任何目标代码。
+    flags = win32process.CREATE_UNICODE_ENVIRONMENT | win32process.CREATE_SUSPENDED
+    process_handle = None
+    thread_handle = None
+    try:
+        if token is None:
+            process_handle, thread_handle, _, _ = win32process.CreateProcess(
+                None,
+                command_line,
+                None,
+                None,
+                True,
+                flags,
+                env,
+                cwd,
+                startup,
+            )
+        else:
+            process_handle, thread_handle, _, _ = win32process.CreateProcessAsUser(
+                token,
+                None,
+                command_line,
+                None,
+                None,
+                True,
+                flags,
+                env,
+                cwd,
+                startup,
+            )
+        win32job.AssignProcessToJobObject(job, process_handle)
+        if win32process.ResumeThread(thread_handle) == -1:
+            raise SandboxUnavailable("ResumeThread 失败")
+    except Exception:
+        if process_handle is not None:
+            try:
+                win32process.TerminateProcess(process_handle, 1)
+            except Exception:
+                pass
+        for handle in (*child_handles, *host_handles, thread_handle, process_handle, job):
+            if handle is not None:
+                try:
+                    handle.Close()
+                except Exception:
+                    pass
+        raise
+
+    thread_handle.Close()
+    stdin_read.Close()
+    stdout_write.Close()
+    stderr_write.Close()
+    stdin_write.Close()
+    return _WindowsChild(process_handle, job, stdout_read, stderr_read)
+
+
+def _drain_pipe(handle: object) -> bytes:
+    import pywintypes
+    import win32file
+
+    chunks: list[bytes] = []
+    while True:
+        try:
+            _, data = win32file.ReadFile(handle, 64 * 1024)
+        except pywintypes.error as error:
+            if error.winerror == _ERROR_BROKEN_PIPE:
+                break
+            raise
+        if not data:
+            break
+        chunks.append(bytes(data))
+    return b"".join(chunks)
+
+
+def _exit_code(process_handle: object) -> int:
+    import win32process
+
+    return int(win32process.GetExitCodeProcess(process_handle))
+
+
+__all__ = ["ProcessResult", "WindowsProcessLauncher"]

--- a/session/manager.py
+++ b/session/manager.py
@@ -302,7 +302,13 @@ class SessionManager:
         self._close_lock = asyncio.Lock()
         self._closed = False
 
-    async def get_or_create(self, session_key: str) -> Session:
+    async def get_or_create(
+        self,
+        session_key: str,
+        *,
+        workspace_id: str | None = None,
+        sandbox_mode: str = "read-only",
+    ) -> Session:
         """优先返回完整缓存；未命中时从 SQLite 重建 Session。"""
 
         self._ensure_open()
@@ -321,7 +327,11 @@ class SessionManager:
             messages = self._store.fetch_session_messages(key)
             if meta is None and not messages:
                 # 新会话先落元数据，确保随后第一条消息可以满足外键约束。
-                meta = self._store.create_session(key)
+                meta = self._store.create_session(
+                    key,
+                    workspace_id=workspace_id,
+                    sandbox_mode=sandbox_mode,
+                )
             now = _now_local()
             session = Session(
                 session_key=key,
@@ -525,6 +535,36 @@ class SessionManager:
             if cached is not None:
                 cached.metadata["title"] = str(title).strip()
             return updated
+
+    async def set_workspace(
+        self,
+        session_key: str,
+        workspace_id: str | None,
+    ) -> dict[str, Any]:
+        """在会话锁内更新可选工作区，缓存消息对象不拥有这项执行策略。"""
+
+        key = self._validate_session_key(session_key)
+        async with self._lock_for(key):
+            return await asyncio.to_thread(
+                self._store.set_session_workspace,
+                key,
+                workspace_id,
+            )
+
+    async def set_sandbox_mode(
+        self,
+        session_key: str,
+        sandbox_mode: str,
+    ) -> dict[str, Any]:
+        """在会话锁内持久化权限，避免与同会话创建流程交错。"""
+
+        key = self._validate_session_key(session_key)
+        async with self._lock_for(key):
+            return await asyncio.to_thread(
+                self._store.update_session_sandbox_mode,
+                key,
+                sandbox_mode,
+            )
 
     async def ensure_default_title(
         self,

--- a/session/store.py
+++ b/session/store.py
@@ -312,8 +312,9 @@ class SessionStore:
             self._conn.execute(
                 """
                 INSERT INTO workspaces (
-                    id, canonical_path, canonical_key, title, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?)
+                    id, canonical_path, canonical_key, title, pinned_at,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, NULL, ?, ?)
                 """,
                 (workspace_id, canonical_path, canonical_key, clean_title, now, now),
             )
@@ -331,9 +332,61 @@ class SessionStore:
         with self._lock:
             self._ensure_open()
             rows = self._conn.execute(
-                "SELECT * FROM workspaces ORDER BY updated_at DESC, id DESC"
+                """
+                SELECT * FROM workspaces
+                ORDER BY
+                    CASE WHEN pinned_at IS NULL THEN 1 ELSE 0 END ASC,
+                    pinned_at ASC,
+                    created_at DESC,
+                    id DESC
+                """
             ).fetchall()
         return [self._row_to_workspace(row) for row in rows]
+
+    def update_workspace(
+        self,
+        workspace_id: str,
+        *,
+        title: str | None = None,
+        pinned: bool | None = None,
+    ) -> dict[str, Any] | None:
+        """幂等更新工作目录展示属性，不改变路径、创建时间或会话归属。"""
+
+        clean_id = str(workspace_id or "").strip()
+        if not clean_id:
+            return None
+        clean_title = None if title is None else str(title).strip()
+        if clean_title is not None and (not clean_title or len(clean_title) > 80):
+            raise ValueError("工作区名称长度必须为 1-80 个字符")
+        if title is None and pinned is None:
+            raise ValueError("至少需要修改一个工作区字段")
+        with self._lock:
+            self._ensure_open()
+            row = self._conn.execute(
+                "SELECT * FROM workspaces WHERE id = ?", (clean_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            next_title = clean_title if clean_title is not None else str(row["title"])
+            current_pinned_at = row["pinned_at"]
+            next_pinned_at = current_pinned_at
+            if pinned is True and current_pinned_at is None:
+                next_pinned_at = _now_iso()
+            elif pinned is False:
+                next_pinned_at = None
+            self._conn.execute(
+                """
+                UPDATE workspaces
+                SET title = ?, pinned_at = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (next_title, next_pinned_at, _now_iso(), clean_id),
+            )
+            self._conn.commit()
+            updated = self._conn.execute(
+                "SELECT * FROM workspaces WHERE id = ?", (clean_id,)
+            ).fetchone()
+        return self._row_to_workspace(updated) if updated is not None else None
 
     def get_workspace(self, workspace_id: str) -> dict[str, Any] | None:
         clean_id = str(workspace_id or "").strip()
@@ -479,6 +532,35 @@ class SessionStore:
         if result is None:
             raise RuntimeError("权限更新后无法读取会话")
         return result
+
+    def set_chat_session_pinned(
+        self,
+        session_key: str,
+        pinned: bool,
+    ) -> dict[str, Any] | None:
+        """只在所属工作目录内置顶会话，不改变对话活动时间。"""
+
+        key = self._validate_session_key(session_key)
+        with self._lock:
+            self._ensure_open()
+            row = self._conn.execute(
+                "SELECT workspace_id, pinned_at FROM sessions WHERE key = ?", (key,)
+            ).fetchone()
+            if row is None:
+                return None
+            if row["workspace_id"] is None:
+                raise ValueError("最近会话不能置顶，请先在工作目录中创建会话")
+            next_pinned_at = row["pinned_at"]
+            if pinned and next_pinned_at is None:
+                next_pinned_at = _now_iso()
+            elif not pinned:
+                next_pinned_at = None
+            self._conn.execute(
+                "UPDATE sessions SET pinned_at = ? WHERE key = ?",
+                (next_pinned_at, key),
+            )
+            self._conn.commit()
+        return self.get_session_meta(key)
 
     def get_session_sandbox(self, session_key: str) -> dict[str, Any] | None:
         key = self._validate_session_key(session_key)
@@ -719,7 +801,7 @@ class SessionStore:
         limit: int = 50,
         offset: int = 0,
     ) -> tuple[list[dict[str, Any]], int]:
-        """按第一次用户提问时间列出聊天会话，并包含运行中但尚未落消息的标题会话。"""
+        """按置顶与对话活动时间列出聊天会话，并保留运行中标题会话。"""
 
         safe_limit = max(1, min(int(limit), 200))
         safe_offset = max(0, int(offset))
@@ -738,6 +820,8 @@ class SessionStore:
                            LIMIT 1
                        ), s.created_at) AS created_at,
                        s.updated_at,
+                       COALESCE(s.last_activity_at, s.created_at) AS last_activity_at,
+                       s.pinned_at,
                        s.metadata,
                        s.workspace_id,
                        s.cwd_snapshot,
@@ -757,10 +841,16 @@ class SessionStore:
                 LEFT JOIN messages m ON m.session_key = s.key
                 LEFT JOIN workspaces w ON w.id = s.workspace_id
                 WHERE s.key LIKE ?
-                 GROUP BY s.key, s.created_at, s.updated_at, s.metadata,
+                 GROUP BY s.key, s.created_at, s.updated_at, s.last_activity_at,
+                          s.pinned_at, s.metadata,
                           s.workspace_id, s.cwd_snapshot, s.sandbox_mode,
                           w.title, w.canonical_path
-                ORDER BY created_at DESC, s.key DESC
+                ORDER BY
+                    CASE WHEN s.workspace_id IS NOT NULL AND s.pinned_at IS NOT NULL
+                        THEN 0 ELSE 1 END ASC,
+                    CASE WHEN s.workspace_id IS NOT NULL THEN s.pinned_at END ASC,
+                    COALESCE(s.last_activity_at, s.created_at) DESC,
+                    s.key DESC
                 """,
                 (prefix,),
             ).fetchall()
@@ -794,10 +884,11 @@ class SessionStore:
             self._conn.execute(
                 """
                 INSERT OR IGNORE INTO sessions (
-                    key, created_at, updated_at, last_consolidated, next_seq, metadata
-                ) VALUES (?, ?, ?, 0, 0, '{}')
+                    key, created_at, updated_at, last_activity_at,
+                    last_consolidated, next_seq, metadata
+                ) VALUES (?, ?, ?, ?, 0, 0, '{}')
                 """,
-                (key, now, now),
+                (key, now, now, now),
             )
             row = self._conn.execute(
                 "SELECT metadata FROM sessions WHERE key = ?",
@@ -815,7 +906,9 @@ class SessionStore:
             self._conn.commit()
             summary = self._conn.execute(
                 """
-                SELECT s.key, s.created_at, s.updated_at, s.metadata,
+                SELECT s.key, s.created_at, s.updated_at,
+                       COALESCE(s.last_activity_at, s.created_at) AS last_activity_at,
+                       s.pinned_at, s.metadata,
                        s.workspace_id, s.cwd_snapshot, s.sandbox_mode,
                        w.title AS workspace_title,
                        w.canonical_path AS workspace_path,
@@ -832,7 +925,8 @@ class SessionStore:
                 LEFT JOIN messages m ON m.session_key = s.key
                 LEFT JOIN workspaces w ON w.id = s.workspace_id
                 WHERE s.key = ?
-                GROUP BY s.key, s.created_at, s.updated_at, s.metadata,
+                GROUP BY s.key, s.created_at, s.updated_at, s.last_activity_at,
+                         s.pinned_at, s.metadata,
                          s.workspace_id, s.cwd_snapshot, s.sandbox_mode,
                          w.title, w.canonical_path
                 """,
@@ -1187,6 +1281,7 @@ class SessionStore:
                     canonical_path TEXT NOT NULL,
                     canonical_key  TEXT NOT NULL UNIQUE,
                     title          TEXT NOT NULL,
+                    pinned_at      TEXT,
                     created_at     TEXT NOT NULL,
                     updated_at     TEXT NOT NULL
                 );
@@ -1195,6 +1290,8 @@ class SessionStore:
                     key               TEXT PRIMARY KEY,
                     created_at        TEXT NOT NULL,
                     updated_at        TEXT NOT NULL,
+                    last_activity_at  TEXT,
+                    pinned_at         TEXT,
                     last_consolidated INTEGER NOT NULL DEFAULT 0,
                     next_seq          INTEGER NOT NULL DEFAULT 0,
                     metadata          TEXT NOT NULL DEFAULT '{}',
@@ -1398,8 +1495,40 @@ class SessionStore:
                 self._conn.execute(
                     "ALTER TABLE sessions ADD COLUMN sandbox_mode TEXT NOT NULL DEFAULT 'read-only'"
                 )
+            if "last_activity_at" not in session_columns:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN last_activity_at TEXT"
+                )
+            if "pinned_at" not in session_columns:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN pinned_at TEXT"
+                )
+            workspace_columns = {
+                str(row["name"])
+                for row in self._conn.execute("PRAGMA table_info(workspaces)")
+            }
+            if "pinned_at" not in workspace_columns:
+                self._conn.execute(
+                    "ALTER TABLE workspaces ADD COLUMN pinned_at TEXT"
+                )
+            # 活动时间只随语义消息推进；旧库从最后一条消息回填，不能继承权限、
+            # 重命名或压缩维护造成的 updated_at 噪声。
             self._conn.execute(
-                "CREATE INDEX IF NOT EXISTS idx_sessions_workspace ON sessions(workspace_id, updated_at)"
+                """
+                UPDATE sessions
+                SET last_activity_at = COALESCE(
+                    (SELECT MAX(messages.ts) FROM messages
+                     WHERE messages.session_key = sessions.key),
+                    sessions.created_at
+                )
+                WHERE last_activity_at IS NULL OR last_activity_at = ''
+                """
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_sessions_workspace_activity ON sessions(workspace_id, last_activity_at)"
+            )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_sessions_pinned ON sessions(workspace_id, pinned_at)"
             )
             surface_columns = {
                 str(row["name"])
@@ -1508,17 +1637,19 @@ class SessionStore:
             self._conn.execute(
                 """
                 INSERT OR IGNORE INTO sessions (
-                    key, created_at, updated_at, last_consolidated, next_seq,
-                    metadata, workspace_id, cwd_snapshot, sandbox_mode
-                ) VALUES (?, ?, ?, 0, 0, '{}', ?, ?, ?)
+                    key, created_at, updated_at, last_activity_at,
+                    last_consolidated, next_seq, metadata, workspace_id,
+                    cwd_snapshot, sandbox_mode
+                ) VALUES (?, ?, ?, ?, 0, 0, '{}', ?, ?, ?)
                 """,
-                (key, now, now, clean_workspace_id, workspace_path, mode),
+                (key, now, now, now, clean_workspace_id, workspace_path, mode),
             )
             self._conn.commit()
             row = self._conn.execute(
                 """
-                SELECT key, created_at, updated_at, last_consolidated,
-                       next_seq, metadata, workspace_id, cwd_snapshot, sandbox_mode
+                SELECT key, created_at, updated_at, last_activity_at, pinned_at,
+                       last_consolidated, next_seq, metadata, workspace_id,
+                       cwd_snapshot, sandbox_mode
                 FROM sessions WHERE key = ?
                 """,
                 (key,),
@@ -1562,11 +1693,11 @@ class SessionStore:
                 self._conn.execute(
                     """
                     INSERT OR IGNORE INTO sessions (
-                        key, created_at, updated_at, last_consolidated,
-                        next_seq, metadata
-                    ) VALUES (?, ?, ?, 0, 0, '{}')
+                        key, created_at, updated_at, last_activity_at,
+                        last_consolidated, next_seq, metadata
+                    ) VALUES (?, ?, ?, ?, 0, 0, '{}')
                     """,
-                    (session_key, now, now),
+                    (session_key, now, now, now),
                 )
                 session_row = self._conn.execute(
                     "SELECT next_seq, metadata FROM sessions WHERE key = ?",
@@ -1616,10 +1747,10 @@ class SessionStore:
                 self._conn.execute(
                     """
                     UPDATE sessions
-                    SET next_seq = ?, updated_at = ?
+                    SET next_seq = ?, updated_at = ?, last_activity_at = ?
                     WHERE key = ?
                     """,
-                    (seq + 1, timestamp, session_key),
+                    (seq + 1, timestamp, timestamp, session_key),
                 )
                 self._conn.commit()
             except Exception:
@@ -2228,8 +2359,9 @@ class SessionStore:
             self._ensure_open()
             row = self._conn.execute(
                 """
-                SELECT key, created_at, updated_at, last_consolidated,
-                       next_seq, metadata, workspace_id, cwd_snapshot, sandbox_mode
+                SELECT key, created_at, updated_at, last_activity_at, pinned_at,
+                       last_consolidated, next_seq, metadata, workspace_id,
+                       cwd_snapshot, sandbox_mode
                 FROM sessions WHERE key = ?
                 """,
                 (key,),
@@ -3047,6 +3179,14 @@ class SessionStore:
             "metadata": _load_json_object(row["metadata"]),
         }
         columns = set(row.keys())
+        if "last_activity_at" in columns:
+            item["last_activity_at"] = str(
+                row["last_activity_at"] or row["created_at"]
+            )
+        if "pinned_at" in columns:
+            item["pinned_at"] = (
+                str(row["pinned_at"]) if row["pinned_at"] is not None else None
+            )
         if "workspace_id" in columns:
             item["workspace_id"] = (
                 str(row["workspace_id"]) if row["workspace_id"] is not None else None
@@ -3066,6 +3206,9 @@ class SessionStore:
             "id": str(row["id"]),
             "canonical_path": path,
             "title": str(row["title"]),
+            "pinned_at": (
+                str(row["pinned_at"]) if row["pinned_at"] is not None else None
+            ),
             "created_at": str(row["created_at"]),
             "updated_at": str(row["updated_at"]),
             "valid": Path(path).is_dir(),

--- a/session/store.py
+++ b/session/store.py
@@ -346,6 +346,20 @@ class SessionStore:
             ).fetchone()
         return self._row_to_workspace(row) if row is not None else None
 
+    def list_workspace_session_keys(self, workspace_id: str) -> list[str]:
+        """返回仍绑定到工作区的会话，用于变更前检查运行状态。"""
+
+        clean_id = str(workspace_id or "").strip()
+        if not clean_id:
+            return []
+        with self._lock:
+            self._ensure_open()
+            rows = self._conn.execute(
+                "SELECT key FROM sessions WHERE workspace_id = ? ORDER BY key",
+                (clean_id,),
+            ).fetchall()
+        return [str(row["key"]) for row in rows]
+
     def delete_workspace(self, workspace_id: str) -> bool:
         """删除注册关系并解除会话绑定，绝不操作用户目录。"""
 

--- a/session/store.py
+++ b/session/store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 import threading
 from dataclasses import dataclass, field
@@ -11,6 +12,7 @@ from datetime import datetime
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 from session.model_surface import INTERRUPTED_TOOL_RESULT_CONTENT
@@ -168,10 +170,20 @@ class SessionStore:
         self._has_fts = False
         self._init_schema()
 
-    def create_session(self, session_key: str) -> dict[str, Any]:
+    def create_session(
+        self,
+        session_key: str,
+        *,
+        workspace_id: str | None = None,
+        sandbox_mode: str = "read-only",
+    ) -> dict[str, Any]:
         """幂等创建会话并返回当前元数据。"""
 
-        return self._create_session_sync(session_key)
+        return self._create_session_sync(
+            session_key,
+            workspace_id=workspace_id,
+            sandbox_mode=sandbox_mode,
+        )
 
     def add_message(self, message: NewMessage) -> dict[str, Any]:
         """原子分配 seq、写入消息并推进会话 next_seq。"""
@@ -275,6 +287,258 @@ class SessionStore:
         """读取会话元数据；不存在时返回 None。"""
 
         return self._get_session_meta_sync(session_key)
+
+    def create_workspace(self, path: str, title: str = "") -> dict[str, Any]:
+        """注册已存在目录；同一真实路径重复提交时返回原记录。"""
+
+        resolved = Path(path).expanduser().resolve(strict=True)
+        if not resolved.is_dir():
+            raise ValueError(f"路径不是目录：{resolved}")
+        canonical_path = str(resolved)
+        canonical_key = os.path.normcase(canonical_path)
+        clean_title = str(title or "").strip() or resolved.name or canonical_path
+        if len(clean_title) > 80:
+            raise ValueError("工作区名称不能超过 80 个字符")
+        now = _now_iso()
+        with self._lock:
+            self._ensure_open()
+            existing = self._conn.execute(
+                "SELECT * FROM workspaces WHERE canonical_key = ?",
+                (canonical_key,),
+            ).fetchone()
+            if existing is not None:
+                return self._row_to_workspace(existing)
+            workspace_id = uuid4().hex
+            self._conn.execute(
+                """
+                INSERT INTO workspaces (
+                    id, canonical_path, canonical_key, title, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (workspace_id, canonical_path, canonical_key, clean_title, now, now),
+            )
+            self._conn.commit()
+            row = self._conn.execute(
+                "SELECT * FROM workspaces WHERE id = ?", (workspace_id,)
+            ).fetchone()
+        if row is None:
+            raise RuntimeError("工作区创建后无法读取")
+        return self._row_to_workspace(row)
+
+    def list_workspaces(self) -> list[dict[str, Any]]:
+        """列出目录注册关系，并动态标记本地路径是否仍然有效。"""
+
+        with self._lock:
+            self._ensure_open()
+            rows = self._conn.execute(
+                "SELECT * FROM workspaces ORDER BY updated_at DESC, id DESC"
+            ).fetchall()
+        return [self._row_to_workspace(row) for row in rows]
+
+    def get_workspace(self, workspace_id: str) -> dict[str, Any] | None:
+        clean_id = str(workspace_id or "").strip()
+        if not clean_id:
+            return None
+        with self._lock:
+            self._ensure_open()
+            row = self._conn.execute(
+                "SELECT * FROM workspaces WHERE id = ?", (clean_id,)
+            ).fetchone()
+        return self._row_to_workspace(row) if row is not None else None
+
+    def delete_workspace(self, workspace_id: str) -> bool:
+        """删除注册关系并解除会话绑定，绝不操作用户目录。"""
+
+        clean_id = str(workspace_id or "").strip()
+        with self._lock:
+            self._ensure_open()
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._conn.execute(
+                    """
+                    UPDATE sessions
+                    SET workspace_id = NULL, cwd_snapshot = NULL,
+                        sandbox_mode = CASE
+                            WHEN sandbox_mode = 'workspace-write' THEN 'read-only'
+                            ELSE sandbox_mode
+                        END,
+                        updated_at = ?
+                    WHERE workspace_id = ?
+                    """,
+                    (_now_iso(), clean_id),
+                )
+                cursor = self._conn.execute(
+                    "DELETE FROM workspaces WHERE id = ?", (clean_id,)
+                )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+        return cursor.rowcount > 0
+
+    def set_session_workspace(
+        self,
+        session_key: str,
+        workspace_id: str | None,
+    ) -> dict[str, Any]:
+        """仅允许空会话原子绑定或解除工作区。"""
+
+        key = self._validate_session_key(session_key)
+        clean_workspace_id = str(workspace_id or "").strip() or None
+        with self._lock:
+            self._ensure_open()
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    "SELECT sandbox_mode FROM sessions WHERE key = ?", (key,)
+                ).fetchone()
+                if row is None:
+                    raise KeyError("会话不存在")
+                used = self._conn.execute(
+                    """
+                    SELECT
+                        (SELECT COUNT(1) FROM messages WHERE session_key = ?) +
+                        (SELECT COUNT(1) FROM surface_events WHERE session_key = ?) +
+                        (SELECT COUNT(1) FROM session_events WHERE session_key = ?)
+                        AS count
+                    """,
+                    (key, key, key),
+                ).fetchone()
+                if int(used["count"] or 0) > 0:
+                    raise ValueError("会话已经开始，不能切换工作目录")
+                workspace = None
+                if clean_workspace_id is not None:
+                    workspace = self._conn.execute(
+                        "SELECT canonical_path FROM workspaces WHERE id = ?",
+                        (clean_workspace_id,),
+                    ).fetchone()
+                    if workspace is None:
+                        raise KeyError("工作区不存在")
+                next_mode = str(row["sandbox_mode"] or "read-only")
+                if clean_workspace_id is None and next_mode == "workspace-write":
+                    next_mode = "read-only"
+                self._conn.execute(
+                    """
+                    UPDATE sessions
+                    SET workspace_id = ?, cwd_snapshot = ?, sandbox_mode = ?, updated_at = ?
+                    WHERE key = ?
+                    """,
+                    (
+                        clean_workspace_id,
+                        str(workspace["canonical_path"]) if workspace else None,
+                        next_mode,
+                        _now_iso(),
+                        key,
+                    ),
+                )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+        result = self.get_session_sandbox(key)
+        if result is None:
+            raise RuntimeError("工作区绑定后无法读取会话")
+        return result
+
+    def update_session_sandbox_mode(
+        self,
+        session_key: str,
+        sandbox_mode: str,
+    ) -> dict[str, Any]:
+        key = self._validate_session_key(session_key)
+        mode = self._validate_sandbox_mode(sandbox_mode)
+        with self._lock:
+            self._ensure_open()
+            row = self._conn.execute(
+                "SELECT workspace_id FROM sessions WHERE key = ?", (key,)
+            ).fetchone()
+            if row is None:
+                raise KeyError("会话不存在")
+            if mode == "workspace-write" and row["workspace_id"] is None:
+                raise ValueError("没有工作目录时不能使用工作区可写权限")
+            self._conn.execute(
+                "UPDATE sessions SET sandbox_mode = ?, updated_at = ? WHERE key = ?",
+                (mode, _now_iso(), key),
+            )
+            self._conn.commit()
+        result = self.get_session_sandbox(key)
+        if result is None:
+            raise RuntimeError("权限更新后无法读取会话")
+        return result
+
+    def get_session_sandbox(self, session_key: str) -> dict[str, Any] | None:
+        key = self._validate_session_key(session_key)
+        with self._lock:
+            self._ensure_open()
+            row = self._conn.execute(
+                """
+                SELECT s.key AS session_id, s.workspace_id, s.cwd_snapshot,
+                       s.sandbox_mode, w.title AS workspace_title,
+                       w.canonical_path AS workspace_path
+                FROM sessions s
+                LEFT JOIN workspaces w ON w.id = s.workspace_id
+                WHERE s.key = ?
+                """,
+                (key,),
+            ).fetchone()
+        if row is None:
+            return None
+        item = dict(row)
+        item["workspace_valid"] = bool(
+            item.get("workspace_path") and Path(str(item["workspace_path"])).is_dir()
+        )
+        item["backend"] = "windows-acl"
+        item["capability"] = "partial"
+        return item
+
+    def create_sandbox_approval(self, request: dict[str, object]) -> None:
+        """写入一条不进入聊天正文的审批审计事实。"""
+
+        with self._lock:
+            self._ensure_open()
+            self._conn.execute(
+                """
+                INSERT INTO sandbox_approvals (
+                    id, session_key, turn_id, call_id, tool_name, operation,
+                    arguments, reason, requested_mode, fingerprint, state,
+                    created_at, decided_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                """,
+                (
+                    str(request["id"]),
+                    str(request["session_id"]),
+                    str(request["turn_id"]),
+                    str(request["call_id"]),
+                    str(request["tool_name"]),
+                    str(request["operation"]),
+                    json.dumps(request.get("arguments", {}), ensure_ascii=False, default=str),
+                    str(request["reason"]),
+                    str(request["requested_mode"]),
+                    str(request["fingerprint"]),
+                    str(request["state"]),
+                    str(request["created_at"]),
+                ),
+            )
+            self._conn.commit()
+
+    def resolve_sandbox_approval(
+        self,
+        request_id: str,
+        state: str,
+        decided_at: str,
+    ) -> bool:
+        with self._lock:
+            self._ensure_open()
+            cursor = self._conn.execute(
+                """
+                UPDATE sandbox_approvals
+                SET state = ?, decided_at = ?
+                WHERE id = ? AND state = 'pending'
+                """,
+                (str(state), str(decided_at), str(request_id)),
+            )
+            self._conn.commit()
+        return cursor.rowcount > 0
 
     def fetch_session_messages(
         self,
@@ -461,6 +725,11 @@ class SessionStore:
                        ), s.created_at) AS created_at,
                        s.updated_at,
                        s.metadata,
+                       s.workspace_id,
+                       s.cwd_snapshot,
+                       s.sandbox_mode,
+                       w.title AS workspace_title,
+                       w.canonical_path AS workspace_path,
                        COUNT(m.id) AS message_count,
                        COALESCE((
                            SELECT first.content
@@ -472,8 +741,11 @@ class SessionStore:
                        ), '') AS first_message_content
                 FROM sessions s
                 LEFT JOIN messages m ON m.session_key = s.key
+                LEFT JOIN workspaces w ON w.id = s.workspace_id
                 WHERE s.key LIKE ?
-                 GROUP BY s.key, s.created_at, s.updated_at, s.metadata
+                 GROUP BY s.key, s.created_at, s.updated_at, s.metadata,
+                          s.workspace_id, s.cwd_snapshot, s.sandbox_mode,
+                          w.title, w.canonical_path
                 ORDER BY created_at DESC, s.key DESC
                 """,
                 (prefix,),
@@ -483,6 +755,10 @@ class SessionStore:
             item = dict(row)
             metadata = _load_json_object(item.pop("metadata", "{}"))
             item["title"] = str(metadata.get("title") or "")
+            item["workspace_valid"] = bool(
+                item.get("workspace_path")
+                and Path(str(item["workspace_path"])).is_dir()
+            )
             if int(item.get("message_count") or 0) <= 0 and not item["title"].strip():
                 continue
             items.append(item)
@@ -526,6 +802,9 @@ class SessionStore:
             summary = self._conn.execute(
                 """
                 SELECT s.key, s.created_at, s.updated_at, s.metadata,
+                       s.workspace_id, s.cwd_snapshot, s.sandbox_mode,
+                       w.title AS workspace_title,
+                       w.canonical_path AS workspace_path,
                        COUNT(m.id) AS message_count,
                        COALESCE((
                            SELECT first.content
@@ -537,8 +816,11 @@ class SessionStore:
                        ), '') AS first_message_content
                 FROM sessions s
                 LEFT JOIN messages m ON m.session_key = s.key
+                LEFT JOIN workspaces w ON w.id = s.workspace_id
                 WHERE s.key = ?
-                GROUP BY s.key, s.created_at, s.updated_at, s.metadata
+                GROUP BY s.key, s.created_at, s.updated_at, s.metadata,
+                         s.workspace_id, s.cwd_snapshot, s.sandbox_mode,
+                         w.title, w.canonical_path
                 """,
                 (key,),
             ).fetchone()
@@ -547,6 +829,10 @@ class SessionStore:
         item = dict(summary)
         metadata = _load_json_object(item.pop("metadata", "{}"))
         item["title"] = str(metadata.get("title") or "")
+        item["workspace_valid"] = bool(
+            item.get("workspace_path")
+            and Path(str(item["workspace_path"])).is_dir()
+        )
         return item
 
     def update_chat_session_title(self, session_key: str, title: str) -> dict[str, Any] | None:
@@ -882,13 +1168,27 @@ class SessionStore:
         with self._lock:
             self._conn.executescript(
                 """
+                CREATE TABLE IF NOT EXISTS workspaces (
+                    id             TEXT PRIMARY KEY,
+                    canonical_path TEXT NOT NULL,
+                    canonical_key  TEXT NOT NULL UNIQUE,
+                    title          TEXT NOT NULL,
+                    created_at     TEXT NOT NULL,
+                    updated_at     TEXT NOT NULL
+                );
+
                 CREATE TABLE IF NOT EXISTS sessions (
                     key               TEXT PRIMARY KEY,
                     created_at        TEXT NOT NULL,
                     updated_at        TEXT NOT NULL,
                     last_consolidated INTEGER NOT NULL DEFAULT 0,
                     next_seq          INTEGER NOT NULL DEFAULT 0,
-                    metadata          TEXT NOT NULL DEFAULT '{}'
+                    metadata          TEXT NOT NULL DEFAULT '{}',
+                    workspace_id      TEXT,
+                    cwd_snapshot      TEXT,
+                    sandbox_mode      TEXT NOT NULL DEFAULT 'read-only',
+                    FOREIGN KEY (workspace_id) REFERENCES workspaces(id)
+                        ON DELETE SET NULL
                 );
 
                 CREATE TABLE IF NOT EXISTS messages (
@@ -1044,7 +1344,48 @@ class SessionStore:
 
                 CREATE INDEX IF NOT EXISTS idx_session_usage_session
                     ON session_usage(session_key);
+
+                CREATE TABLE IF NOT EXISTS sandbox_approvals (
+                    id             TEXT PRIMARY KEY,
+                    session_key    TEXT NOT NULL,
+                    turn_id        TEXT NOT NULL,
+                    call_id        TEXT NOT NULL,
+                    tool_name      TEXT NOT NULL,
+                    operation      TEXT NOT NULL,
+                    arguments      TEXT NOT NULL,
+                    reason         TEXT NOT NULL,
+                    requested_mode TEXT NOT NULL,
+                    fingerprint    TEXT NOT NULL,
+                    state          TEXT NOT NULL,
+                    created_at     TEXT NOT NULL,
+                    decided_at     TEXT,
+                    UNIQUE (session_key, turn_id, call_id),
+                    FOREIGN KEY (session_key) REFERENCES sessions(key)
+                        ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_sandbox_approvals_session_state
+                    ON sandbox_approvals(session_key, state, created_at);
                 """
+            )
+            session_columns = {
+                str(row["name"])
+                for row in self._conn.execute("PRAGMA table_info(sessions)")
+            }
+            if "workspace_id" not in session_columns:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN workspace_id TEXT REFERENCES workspaces(id) ON DELETE SET NULL"
+                )
+            if "cwd_snapshot" not in session_columns:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN cwd_snapshot TEXT"
+                )
+            if "sandbox_mode" not in session_columns:
+                self._conn.execute(
+                    "ALTER TABLE sessions ADD COLUMN sandbox_mode TEXT NOT NULL DEFAULT 'read-only'"
+                )
+            self._conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_sessions_workspace ON sessions(workspace_id, updated_at)"
             )
             surface_columns = {
                 str(row["name"])
@@ -1126,24 +1467,44 @@ class SessionStore:
                 (json.dumps(metadata, ensure_ascii=False), str(row["key"])),
             )
 
-    def _create_session_sync(self, session_key: str) -> dict[str, Any]:
+    def _create_session_sync(
+        self,
+        session_key: str,
+        *,
+        workspace_id: str | None = None,
+        sandbox_mode: str = "read-only",
+    ) -> dict[str, Any]:
         key = self._validate_session_key(session_key)
+        clean_workspace_id = str(workspace_id or "").strip() or None
+        mode = self._validate_sandbox_mode(sandbox_mode)
         now = _now_iso()
         with self._lock:
             self._ensure_open()
+            workspace_path: str | None = None
+            if clean_workspace_id is not None:
+                workspace = self._conn.execute(
+                    "SELECT canonical_path FROM workspaces WHERE id = ?",
+                    (clean_workspace_id,),
+                ).fetchone()
+                if workspace is None:
+                    raise KeyError("工作区不存在")
+                workspace_path = str(workspace["canonical_path"])
+            if mode == "workspace-write" and clean_workspace_id is None:
+                raise ValueError("没有工作目录时不能使用工作区可写权限")
             self._conn.execute(
                 """
                 INSERT OR IGNORE INTO sessions (
-                    key, created_at, updated_at, last_consolidated, next_seq, metadata
-                ) VALUES (?, ?, ?, 0, 0, '{}')
+                    key, created_at, updated_at, last_consolidated, next_seq,
+                    metadata, workspace_id, cwd_snapshot, sandbox_mode
+                ) VALUES (?, ?, ?, 0, 0, '{}', ?, ?, ?)
                 """,
-                (key, now, now),
+                (key, now, now, clean_workspace_id, workspace_path, mode),
             )
             self._conn.commit()
             row = self._conn.execute(
                 """
                 SELECT key, created_at, updated_at, last_consolidated,
-                       next_seq, metadata
+                       next_seq, metadata, workspace_id, cwd_snapshot, sandbox_mode
                 FROM sessions WHERE key = ?
                 """,
                 (key,),
@@ -1854,7 +2215,7 @@ class SessionStore:
             row = self._conn.execute(
                 """
                 SELECT key, created_at, updated_at, last_consolidated,
-                       next_seq, metadata
+                       next_seq, metadata, workspace_id, cwd_snapshot, sandbox_mode
                 FROM sessions WHERE key = ?
                 """,
                 (key,),
@@ -2663,13 +3024,37 @@ class SessionStore:
 
     @staticmethod
     def _row_to_session(row: sqlite3.Row) -> dict[str, Any]:
-        return {
+        item = {
             "key": str(row["key"]),
             "created_at": str(row["created_at"]),
             "updated_at": str(row["updated_at"]),
             "last_consolidated": int(row["last_consolidated"] or 0),
             "next_seq": int(row["next_seq"] or 0),
             "metadata": _load_json_object(row["metadata"]),
+        }
+        columns = set(row.keys())
+        if "workspace_id" in columns:
+            item["workspace_id"] = (
+                str(row["workspace_id"]) if row["workspace_id"] is not None else None
+            )
+        if "cwd_snapshot" in columns:
+            item["cwd_snapshot"] = (
+                str(row["cwd_snapshot"]) if row["cwd_snapshot"] is not None else None
+            )
+        if "sandbox_mode" in columns:
+            item["sandbox_mode"] = str(row["sandbox_mode"] or "read-only")
+        return item
+
+    @staticmethod
+    def _row_to_workspace(row: sqlite3.Row) -> dict[str, Any]:
+        path = str(row["canonical_path"])
+        return {
+            "id": str(row["id"]),
+            "canonical_path": path,
+            "title": str(row["title"]),
+            "created_at": str(row["created_at"]),
+            "updated_at": str(row["updated_at"]),
+            "valid": Path(path).is_dir(),
         }
 
     @staticmethod
@@ -2848,6 +3233,13 @@ class SessionStore:
         if not key:
             raise ValueError("session_key 不能为空")
         return key
+
+    @staticmethod
+    def _validate_sandbox_mode(mode: str) -> str:
+        value = str(mode or "").strip()
+        if value not in {"read-only", "workspace-write", "danger-full-access"}:
+            raise ValueError(f"不支持的沙箱权限：{value or 'empty'}")
+        return value
 
     def _ensure_open(self) -> None:
         if self._closed:

--- a/tests/e2e/backend/test_mcp_closed_loop.py
+++ b/tests/e2e/backend/test_mcp_closed_loop.py
@@ -75,6 +75,11 @@ def test_websocket_mcp_turn_commits_and_next_turn_loads_history(tmp_path: Path) 
         {"BEANAGENT_MCP_TEST_LOG": str(tmp_path / "mcp.jsonl")},
     )
     core = build_core_runtime(config, workspace, provider=provider)
+    # MCP stdio 子进程不经过 Windows ACL 边界，只允许已确认的完全访问会话调用。
+    core.sessions.store.create_session(
+        "web:mcp",
+        sandbox_mode="danger-full-access",
+    )
     committed: list[TurnCommitted] = []
     core.event_bus.on(TurnCommitted, committed.append)
     app = create_fastapi_app(core)

--- a/tests/e2e/frontend/chat.spec.ts
+++ b/tests/e2e/frontend/chat.spec.ts
@@ -120,6 +120,16 @@ test("工作目录与会话权限可以在输入框切换", async ({ page }) => 
   await expect(page.getByRole("button", { name: "权限：工作区可写" })).toBeVisible();
 });
 
+test("添加工作目录使用本机选择器返回路径", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop", "桌面侧栏覆盖即可");
+  await page.getByRole("button", { name: "添加工作目录" }).click();
+  const dialog = page.getByRole("dialog", { name: "添加工作目录" });
+  await expect(dialog.getByLabel("绝对路径")).toHaveCount(0);
+  await dialog.getByRole("button", { name: /选择 Bean 可读取和编辑的文件夹/ }).click();
+  await expect(dialog.getByText("D:/projects/picked-by-native-dialog")).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "添加" })).toBeEnabled();
+});
+
 test("完全访问需要显式风险确认", async ({ page }) => {
   await page.getByRole("button", { name: "权限：只读" }).click();
   await page.getByRole("menuitemradio", { name: /完全访问/ }).click();

--- a/tests/e2e/frontend/chat.spec.ts
+++ b/tests/e2e/frontend/chat.spec.ts
@@ -56,7 +56,7 @@ test("展示结构化错误并停止活跃 Turn", async ({ page }) => {
 
   await input.fill("等待停止");
   await page.getByRole("button", { name: "发送" }).click();
-  await page.getByRole("button", { name: "停止" }).click();
+  await page.getByRole("button", { name: "停止", exact: true }).click();
   await expect(page.getByText("已停止")).toBeVisible();
 });
 
@@ -106,8 +106,42 @@ test("加载历史会话并新建空会话", async ({ page }, testInfo) => {
   await expect(page.getByRole("button", { name: "打开会话列表" })).toBeHidden();
   await page.getByRole("button", { name: "历史问题", exact: true }).click();
   await expect(page.getByText("历史回答")).toBeVisible();
-  await page.getByRole("button", { name: "新建会话" }).click();
+  await page.getByRole("button", { name: "新建会话", exact: true }).click();
   await expect(page.getByText("从一个具体问题开始")).toBeVisible();
+});
+
+test("工作目录与会话权限可以在输入框切换", async ({ page }) => {
+  await page.getByRole("button", { name: "工作目录：无工作目录" }).click();
+  await page.getByRole("menuitemradio", { name: /Bean Demo/ }).click();
+  await page.getByRole("button", { name: "权限：只读" }).click();
+  await page.getByRole("menuitemradio", { name: /工作区可写/ }).click();
+
+  await expect(page.getByRole("button", { name: "工作目录：Bean Demo" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "权限：工作区可写" })).toBeVisible();
+});
+
+test("完全访问需要显式风险确认", async ({ page }) => {
+  await page.getByRole("button", { name: "权限：只读" }).click();
+  await page.getByRole("menuitemradio", { name: /完全访问/ }).click();
+  const dialog = page.getByRole("dialog", { name: "启用完全访问？" });
+  const confirm = dialog.getByRole("button", { name: "启用完全访问" });
+  await expect(confirm).toBeDisabled();
+  await dialog.getByRole("checkbox").check();
+  await confirm.click();
+  await expect(page.getByRole("button", { name: "权限：完全访问" })).toBeVisible();
+});
+
+test("越权请求用审批面板替换输入框并只允许单次决定", async ({ page }) => {
+  const input = page.getByPlaceholder("输入消息，或附加文本与图片");
+  await input.fill("审批测试");
+  await page.getByRole("button", { name: "发送" }).click();
+
+  await expect(page.getByLabel("待处理权限审批")).toBeVisible();
+  await expect(page.getByText("Set-Content D:\\outside.txt 'approved'")).toBeVisible();
+  await expect(input).toHaveCount(0);
+  await page.getByRole("button", { name: "仅允许本次" }).click();
+  await expect(page.getByText("审批流程已结束")).toBeVisible();
+  await expect(page.getByPlaceholder("输入消息，或附加文本与图片")).toBeVisible();
 });
 
 test("长回答只滚动消息区并始终保留输入框", async ({ page }) => {

--- a/tests/e2e/frontend/fake_server.py
+++ b/tests/e2e/frontend/fake_server.py
@@ -28,6 +28,7 @@ DEMO_WORKSPACE = {
     "title": "Bean Demo",
     "created_at": "2026-09-03T08:00:00+08:00",
     "updated_at": "2026-09-03T08:00:00+08:00",
+    "pinned_at": None,
     "valid": True,
 }
 
@@ -44,6 +45,8 @@ def sessions() -> dict[str, object]:
             "key": "web:history",
             "created_at": "2026-07-16T08:00:00+08:00",
             "updated_at": "2026-07-16T09:00:00+08:00",
+            "last_activity_at": "2026-07-16T09:00:00+08:00",
+            "pinned_at": None,
             "message_count": 2,
             "first_message_content": "历史问题",
             "workspace_id": DEMO_WORKSPACE["id"],
@@ -74,9 +77,46 @@ async def register_workspace(request: Request) -> dict[str, object]:
     }
 
 
+@app.post("/api/chat/workspaces/pick")
+def pick_workspace() -> dict[str, str]:
+    return {"path": "D:/projects/picked-by-native-dialog"}
+
+
+@app.patch("/api/chat/workspaces/{workspace_id}")
+async def update_workspace(workspace_id: str, request: Request) -> dict[str, object]:
+    payload = await request.json()
+    return {
+        **DEMO_WORKSPACE,
+        "id": workspace_id,
+        "title": str(payload.get("title") or DEMO_WORKSPACE["title"]),
+        "pinned_at": (
+            "2026-09-03T12:00:00+08:00" if payload.get("pinned") else None
+        ),
+    }
+
+
+@app.post("/api/chat/workspaces/{workspace_id}/open", status_code=204)
+def open_workspace(workspace_id: str) -> None:
+    return None
+
+
 @app.delete("/api/chat/workspaces/{workspace_id}", status_code=204)
 def delete_workspace(workspace_id: str) -> None:
     return None
+
+
+@app.patch("/api/chat/sessions/{session_key:path}")
+async def update_session(session_key: str, request: Request) -> dict[str, object]:
+    payload = await request.json()
+    return {
+        "key": session_key,
+        "title": str(payload.get("title") or ""),
+        "updated_at": "2026-09-03T12:00:00+08:00",
+        "last_activity_at": "2026-07-16T09:00:00+08:00",
+        "pinned_at": (
+            "2026-09-03T12:00:00+08:00" if payload.get("pinned") else None
+        ),
+    }
 
 
 @app.get("/api/chat/sessions/{session_key:path}/messages")

--- a/tests/e2e/frontend/fake_server.py
+++ b/tests/e2e/frontend/fake_server.py
@@ -22,6 +22,15 @@ UPLOADS.mkdir(parents=True, exist_ok=True)
 app = FastAPI()
 app.mount("/assets", StaticFiles(directory=STATIC), name="assets")
 
+DEMO_WORKSPACE = {
+    "id": "workspace-demo",
+    "canonical_path": "D:/projects/bean-demo",
+    "title": "Bean Demo",
+    "created_at": "2026-09-03T08:00:00+08:00",
+    "updated_at": "2026-09-03T08:00:00+08:00",
+    "valid": True,
+}
+
 
 @app.get("/")
 def index() -> FileResponse:
@@ -37,9 +46,37 @@ def sessions() -> dict[str, object]:
             "updated_at": "2026-07-16T09:00:00+08:00",
             "message_count": 2,
             "first_message_content": "历史问题",
+            "workspace_id": DEMO_WORKSPACE["id"],
+            "workspace_title": DEMO_WORKSPACE["title"],
+            "workspace_path": DEMO_WORKSPACE["canonical_path"],
+            "workspace_valid": True,
+            "sandbox_mode": "workspace-write",
         }],
         "total": 1,
     }
+
+
+@app.get("/api/chat/workspaces")
+def workspaces() -> dict[str, object]:
+    return {"items": [DEMO_WORKSPACE]}
+
+
+@app.post("/api/chat/workspaces", status_code=201)
+async def register_workspace(request: Request) -> dict[str, object]:
+    payload = await request.json()
+    path = str(payload.get("path") or "").strip()
+    title = str(payload.get("title") or "").strip()
+    return {
+        **DEMO_WORKSPACE,
+        "id": "workspace-added",
+        "canonical_path": path,
+        "title": title or Path(path).name,
+    }
+
+
+@app.delete("/api/chat/workspaces/{workspace_id}", status_code=204)
+def delete_workspace(workspace_id: str) -> None:
+    return None
 
 
 @app.get("/api/chat/sessions/{session_key:path}/messages")
@@ -59,6 +96,11 @@ def messages(session_key: str) -> dict[str, object]:
 @app.get("/api/chat/sessions/{session_key:path}/notifications")
 def notifications(session_key: str) -> dict[str, object]:
     return {"items": [], "total": 0, "session_id": session_key}
+
+
+@app.get("/api/chat/sessions/{session_key:path}/turns")
+def turns(session_key: str) -> dict[str, object]:
+    return {"items": [], "session_id": session_key}
 
 
 @app.post("/api/chat/uploads")
@@ -87,14 +129,85 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     await websocket.accept()
     active_turn = ""
     queued_request = ""
+    current_session_id = "web:playwright"
+    workspace_id: str | None = None
+    sandbox_mode = "read-only"
+    pending_approval = ""
+
+    def sandbox_snapshot() -> dict[str, object]:
+        has_workspace = workspace_id == DEMO_WORKSPACE["id"]
+        return {
+            "session_id": current_session_id,
+            "workspace_id": workspace_id,
+            "cwd_snapshot": DEMO_WORKSPACE["canonical_path"] if has_workspace else None,
+            "workspace_title": DEMO_WORKSPACE["title"] if has_workspace else None,
+            "workspace_path": DEMO_WORKSPACE["canonical_path"] if has_workspace else None,
+            "workspace_valid": has_workspace,
+            "sandbox_mode": sandbox_mode,
+            "backend": "windows-acl",
+            "capability": "partial",
+        }
+
+    def approval_snapshot() -> dict[str, object]:
+        return {
+            "id": pending_approval,
+            "session_id": current_session_id,
+            "turn_id": active_turn,
+            "call_id": "call-approval",
+            "tool_name": "shell",
+            "operation": "执行完整 Shell 命令",
+            "arguments": {
+                "command": "Set-Content D:\\outside.txt 'approved'",
+                "cwd": "D:/projects/bean-demo",
+            },
+            "reason": "命令需要写入当前工作目录之外的位置",
+            "requested_mode": "danger-full-access",
+            "fingerprint": "playwright-fingerprint",
+            "state": "pending",
+            "created_at": "2026-09-03T12:00:00+08:00",
+        }
+
     try:
         while True:
             frame = await websocket.receive_json()
             frame_type = str(frame.get("type") or "")
             request_id = str(frame.get("request_id") or "")
-            session_id = str(frame.get("session_id") or "web:playwright")
+            session_id = str(frame.get("session_id") or current_session_id)
             if frame_type == "session.create":
-                await websocket.send_json({"type": "session.created", "request_id": request_id, "session_id": "web:playwright"})
+                current_session_id = "web:playwright"
+                workspace_id = str(frame.get("workspace_id") or "") or None
+                sandbox_mode = str(frame.get("sandbox_mode") or "read-only")
+                await websocket.send_json({"type": "session.created", "request_id": request_id, "session_id": current_session_id})
+                await websocket.send_json({"type": "sandbox.updated", "request_id": request_id, "sandbox": sandbox_snapshot()})
+                continue
+            if frame_type == "session.subscribe":
+                current_session_id = session_id
+                if session_id == "web:history":
+                    workspace_id = str(DEMO_WORKSPACE["id"])
+                    sandbox_mode = "workspace-write"
+                await websocket.send_json({"type": "session.subscribed", "request_id": request_id, "session_id": session_id})
+                await websocket.send_json({"type": "sandbox.updated", "request_id": "", "sandbox": sandbox_snapshot()})
+                if pending_approval:
+                    await websocket.send_json({"type": "approval.requested", "session_id": session_id, "approval": approval_snapshot()})
+                continue
+            if frame_type == "sandbox.mode.set":
+                sandbox_mode = str(frame.get("sandbox_mode") or "read-only")
+                await websocket.send_json({"type": "sandbox.updated", "request_id": request_id, "sandbox": sandbox_snapshot()})
+                continue
+            if frame_type == "workspace.bind":
+                workspace_id = str(frame.get("workspace_id") or "") or None
+                if workspace_id is None and sandbox_mode == "workspace-write":
+                    sandbox_mode = "read-only"
+                await websocket.send_json({"type": "sandbox.updated", "request_id": request_id, "sandbox": sandbox_snapshot()})
+                continue
+            if frame_type == "approval.decide":
+                approval_id = str(frame.get("approval_id") or "")
+                decision = str(frame.get("decision") or "rejected")
+                await websocket.send_json({"type": "approval.resolved", "request_id": request_id, "session_id": session_id, "approval_id": approval_id, "decision": decision})
+                if approval_id == pending_approval:
+                    await websocket.send_json({"type": "message.final", "request_id": request_id, "session_id": session_id, "turn_id": active_turn, "content": "审批流程已结束", "thinking": "", "media": []})
+                    pending_approval = ""
+                    active_turn = ""
                 continue
             if frame_type == "turn.stop":
                 status = "cancelled" if queued_request else "interrupted"
@@ -104,6 +217,13 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                 continue
             if frame_type != "message.send":
                 continue
+            if not frame.get("session_id"):
+                current_session_id = "web:playwright"
+                session_id = current_session_id
+                workspace_id = str(frame.get("workspace_id") or "") or None
+                sandbox_mode = str(frame.get("sandbox_mode") or "read-only")
+                await websocket.send_json({"type": "session.created", "request_id": request_id, "session_id": session_id})
+                await websocket.send_json({"type": "sandbox.updated", "request_id": request_id, "sandbox": sandbox_snapshot()})
             text = str(frame.get("text") or "")
             if text == "触发错误":
                 await websocket.send_json({"type": "error", "request_id": request_id, "code": "fake_error", "message": "Fake 结构化错误"})
@@ -116,6 +236,14 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                 continue
             active_turn = f"turn-{request_id}"
             await websocket.send_json({"type": "turn.started", "request_id": request_id, "session_id": session_id, "turn_id": active_turn})
+            if text == "审批测试":
+                pending_approval = "approval-playwright"
+                await websocket.send_json({
+                    "type": "approval.requested",
+                    "session_id": session_id,
+                    "approval": approval_snapshot(),
+                })
+                continue
             if text == "等待停止":
                 continue
             if text == "长回答布局测试":

--- a/tests/unit/agent/test_channel_media.py
+++ b/tests/unit/agent/test_channel_media.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -46,6 +47,31 @@ class Socket:
 
     async def send_json(self, data: dict) -> None:
         self.frames.append(data)
+
+
+class Approvals:
+    def __init__(self) -> None:
+        self.available: list[tuple[str, bool]] = []
+        self.decisions: list[tuple[str, str, str]] = []
+
+    async def set_session_available(self, session_id: str, available: bool) -> None:
+        self.available.append((session_id, available))
+
+    async def pending_for_session(self, session_id: str) -> list[object]:
+        if session_id != "web:chat":
+            return []
+        return [SimpleNamespace(to_wire=lambda: {
+            "id": "approval-1",
+            "session_id": session_id,
+            "state": "pending",
+        })]
+
+    async def decide(self, request_id: str, session_id: str, decision: str) -> str:
+        self.decisions.append((request_id, session_id, decision))
+        return decision
+
+    async def cancel_session(self, _session_id: str) -> None:
+        return None
 
 
 @pytest.mark.asyncio
@@ -160,6 +186,94 @@ async def test_session_subscribe_replays_active_turn_snapshot() -> None:
         "tools": [],
         "status": "running",
     }
+    await channel.close()
+
+
+@pytest.mark.asyncio
+async def test_web_channel_handles_sandbox_workspace_and_approval_protocol() -> None:
+    bus = MessageBus()
+    approvals = Approvals()
+    mode_updates: list[tuple[str, str]] = []
+    workspace_updates: list[tuple[str, str | None]] = []
+
+    async def load_sandbox(session_id: str) -> dict:
+        return {
+            "session_id": session_id,
+            "workspace_id": "workspace-1",
+            "workspace_path": "D:/project",
+            "sandbox_mode": "workspace-write",
+            "workspace_valid": True,
+        }
+
+    async def set_mode(session_id: str, mode: str) -> dict:
+        mode_updates.append((session_id, mode))
+        return {**await load_sandbox(session_id), "sandbox_mode": mode}
+
+    async def set_workspace(session_id: str, workspace_id: str | None) -> dict:
+        workspace_updates.append((session_id, workspace_id))
+        return {**await load_sandbox(session_id), "workspace_id": workspace_id}
+
+    channel = WebChannel(
+        bus,
+        EventBus(),
+        Interrupt(),
+        sandbox_loader=load_sandbox,
+        sandbox_mode_writer=set_mode,
+        workspace_writer=set_workspace,
+        approvals=approvals,  # type: ignore[arg-type]
+    )
+    socket = Socket()
+
+    await channel.handle_frame(socket, {
+        "type": "session.subscribe",
+        "request_id": "subscribe",
+        "session_id": "web:chat",
+    })
+
+    assert [frame["type"] for frame in socket.frames[:3]] == [
+        "session.subscribed",
+        "sandbox.updated",
+        "approval.requested",
+    ]
+    assert approvals.available[-1] == ("web:chat", True)
+
+    await channel.handle_frame(socket, {
+        "type": "sandbox.mode.set",
+        "request_id": "mode-denied",
+        "session_id": "web:chat",
+        "sandbox_mode": "danger-full-access",
+    })
+    assert socket.frames[-1]["code"] == "invalid_sandbox"
+
+    await channel.handle_frame(socket, {
+        "type": "sandbox.mode.set",
+        "request_id": "mode-ok",
+        "session_id": "web:chat",
+        "sandbox_mode": "danger-full-access",
+        "risk_confirmed": True,
+    })
+    assert mode_updates == [("web:chat", "danger-full-access")]
+    assert socket.frames[-1]["sandbox"]["sandbox_mode"] == "danger-full-access"
+
+    await channel.handle_frame(socket, {
+        "type": "workspace.bind",
+        "request_id": "workspace",
+        "session_id": "web:chat",
+        "workspace_id": "workspace-2",
+    })
+    assert workspace_updates == [("web:chat", "workspace-2")]
+
+    await channel.handle_frame(socket, {
+        "type": "approval.decide",
+        "request_id": "approval",
+        "session_id": "web:chat",
+        "approval_id": "approval-1",
+        "decision": "allowed-once",
+    })
+    assert approvals.decisions == [
+        ("approval-1", "web:chat", "allowed-once")
+    ]
+    assert socket.frames[-1]["type"] == "approval.resolved"
     await channel.close()
 
 

--- a/tests/unit/agent/test_pipeline.py
+++ b/tests/unit/agent/test_pipeline.py
@@ -7,6 +7,7 @@ import json
 import logging
 from io import BytesIO
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from PIL import Image
@@ -91,6 +92,59 @@ class Memory:
     def read_self(self): return ""
     def get_memory_context(self): return ""
     def read_recent_context(self): return ""
+
+
+@pytest.mark.asyncio
+async def test_restricted_session_does_not_execute_mcp_tool(tmp_path: Path) -> None:
+    class McpTool(Tool):
+        name = "mcp_demo__write"
+        description = "外部扩展写入"
+        parameters = {"type": "object", "properties": {}}
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def execute(self, **kwargs):
+            self.calls += 1
+            return "should-not-run"
+
+    class McpProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.messages: list[list[dict[str, object]]] = []
+
+        async def chat(self, messages, tools=None, **kwargs):
+            self.calls += 1
+            self.messages.append([dict(item) for item in messages])
+            if self.calls == 1:
+                return LLMResponse(
+                    None,
+                    [ToolCall("mcp-call", "mcp_demo__write", {})],
+                )
+            return LLMResponse("完成")
+
+    tool = McpTool()
+    registry = ToolRegistry()
+    registry.register(tool, source_type="mcp", source_name="demo")
+    provider = McpProvider()
+    pipeline = Pipeline(
+        provider,
+        registry,
+        EventBus(),
+        _assembler(tmp_path),
+        workspace=str(tmp_path),
+        sandbox_guard=SimpleNamespace(
+            policy=lambda _session_key: SimpleNamespace(mode="read-only")
+        ),
+    )
+
+    await pipeline.process(
+        InboundMessage("web", "u", "restricted", "调用扩展"),
+        turn_id="turn-mcp",
+    )
+
+    assert tool.calls == 0
+    assert "完全访问会话" in str(provider.messages[1])
 
 
 @pytest.mark.asyncio

--- a/tests/unit/bootstrap/test_app.py
+++ b/tests/unit/bootstrap/test_app.py
@@ -96,15 +96,33 @@ async def test_build_core_runtime_allows_unrestricted_reads_but_keeps_writes_sco
     outside.write_text("class Main {}", encoding="utf-8")
 
     runtime = build_core_runtime(config, workspace, provider=Provider())
-    result = await runtime.tools.execute("read_file", {"path": str(outside)})
-    rejected_write = await runtime.tools.execute(
-        "write_file",
-        {"path": str(tmp_path / "outside" / "created.txt"), "content": "blocked"},
+    project = tmp_path / "source"
+    project.mkdir()
+    registered = runtime.sessions.store.create_workspace(str(project))
+    await runtime.sessions.get_or_create(
+        "web:scoped",
+        workspace_id=str(registered["id"]),
+        sandbox_mode="workspace-write",
     )
+    context = {"session_key": "web:scoped", "turn_id": "turn-1", "call_id": "call-1"}
+    try:
+        result = await runtime.tools.execute(
+            "read_file",
+            {"path": str(outside)},
+            context=context,
+        )
+        rejected_write = await runtime.tools.execute(
+            "write_file",
+            {"path": str(tmp_path / "outside" / "created.txt"), "content": "blocked"},
+            context=context,
+        )
 
-    assert "class Main {}" in str(result)
-    assert "超出允许目录" in str(rejected_write)
-    assert not (tmp_path / "outside" / "created.txt").exists()
+        assert "class Main {}" in str(result)
+        assert "审批界面" in str(rejected_write)
+        assert not (tmp_path / "outside" / "created.txt").exists()
+    finally:
+        await runtime.sandbox_runtime.close()
+        await runtime.sessions.close()
 
 
 def test_fastapi_exposes_real_websocket_route(tmp_path: Path) -> None:

--- a/tests/unit/bootstrap/test_chat_api.py
+++ b/tests/unit/bootstrap/test_chat_api.py
@@ -118,6 +118,38 @@ def test_workspace_api_and_session_sandbox_closed_loop(tmp_path: Path) -> None:
     assert project.exists()
 
 
+def test_workspace_api_refuses_to_detach_busy_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, runtime = _client(tmp_path)
+    project = tmp_path / "busy-project"
+    project.mkdir()
+    workspace = runtime.sessions.store.create_workspace(str(project))
+    session_id = "web:busy-workspace"
+    runtime.sessions.store.create_session(
+        session_id,
+        workspace_id=workspace["id"],
+        sandbox_mode="workspace-write",
+    )
+    monkeypatch.setattr(
+        runtime.agent_loop,
+        "is_session_busy",
+        lambda key: key == session_id,
+    )
+
+    with client:
+        removed = client.delete(f"/api/chat/workspaces/{workspace['id']}")
+        assert runtime.sessions.store.get_workspace(workspace["id"]) is not None
+        assert (
+            runtime.sessions.store.get_session_meta(session_id)["workspace_id"]
+            == workspace["id"]
+        )
+
+    assert removed.status_code == 409
+    assert "正在运行或排队" in removed.json()["detail"]
+
+
 def test_chat_api_lists_titled_running_session_without_messages(tmp_path: Path) -> None:
     client, runtime = _client(tmp_path)
     runtime.sessions.store.ensure_default_chat_session_title(

--- a/tests/unit/bootstrap/test_chat_api.py
+++ b/tests/unit/bootstrap/test_chat_api.py
@@ -11,6 +11,11 @@ from PIL import Image
 
 from agent.config_models import Config
 from bootstrap.app import build_core_runtime, create_fastapi_app
+from bootstrap.native_folder_picker import (
+    NativeHostError,
+    NativeHostUnavailable,
+    NativePickerBusy,
+)
 from session.store import NewMessage, NewSessionEvent
 
 
@@ -25,6 +30,23 @@ class Provider:
         return None
 
 
+class FakeDirectoryPicker:
+    def __init__(self, result: Path | None = None) -> None:
+        self.result = result
+        self.error: Exception | None = None
+        self.opened: list[Path] = []
+
+    def pick_directory(self) -> Path | None:
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+    def open_directory(self, path: Path) -> None:
+        if self.error is not None:
+            raise self.error
+        self.opened.append(path)
+
+
 def _client(tmp_path: Path) -> tuple[TestClient, object]:
     config = Config()
     config.memory.enabled = False
@@ -35,6 +57,98 @@ def _client(tmp_path: Path) -> tuple[TestClient, object]:
         provider=Provider(),
     )
     return TestClient(create_fastapi_app(runtime)), runtime
+
+
+def _native_client(
+    tmp_path: Path,
+    picker: FakeDirectoryPicker,
+    *,
+    client_host: str = "127.0.0.1",
+) -> tuple[TestClient, object]:
+    config = Config()
+    config.memory.enabled = False
+    config.agent.workdir = str(tmp_path / "workdir")
+    runtime = build_core_runtime(
+        config,
+        tmp_path / "workspace",
+        provider=Provider(),
+    )
+    app = create_fastapi_app(runtime, directory_picker=picker)
+    return TestClient(app, client=(client_host, 50000)), runtime
+
+
+def test_native_workspace_picker_is_local_non_persisting_and_maps_host_errors(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "picked-project"
+    project.mkdir()
+    picker = FakeDirectoryPicker(project)
+    client, runtime = _native_client(tmp_path, picker)
+
+    with client:
+        selected = client.post("/api/chat/workspaces/pick")
+        assert selected.status_code == 200
+        assert selected.json() == {"path": str(project.resolve())}
+        assert runtime.sessions.store.list_workspaces() == []
+
+        picker.result = None
+        assert client.post("/api/chat/workspaces/pick").json() == {"path": None}
+
+        for error, status in (
+            (NativePickerBusy("busy"), 409),
+            (NativeHostUnavailable("unavailable"), 501),
+            (NativeHostError("failed"), 503),
+        ):
+            picker.error = error
+            response = client.post("/api/chat/workspaces/pick")
+            assert response.status_code == status
+            assert response.json()["detail"] == str(error)
+
+
+def test_native_workspace_picker_rejects_remote_client(tmp_path: Path) -> None:
+    picker = FakeDirectoryPicker()
+    client, _runtime = _native_client(
+        tmp_path,
+        picker,
+        client_host="192.0.2.10",
+    )
+
+    with client:
+        response = client.post("/api/chat/workspaces/pick")
+
+    assert response.status_code == 403
+    assert "回环地址" in response.json()["detail"]
+
+
+def test_workspace_and_session_management_endpoints(tmp_path: Path) -> None:
+    project = tmp_path / "managed-project"
+    project.mkdir()
+    picker = FakeDirectoryPicker()
+    client, runtime = _native_client(tmp_path, picker)
+    workspace = runtime.sessions.store.create_workspace(str(project), "旧名称")
+    runtime.sessions.store.create_session(
+        "web:managed",
+        workspace_id=workspace["id"],
+    )
+
+    with client:
+        updated = client.patch(
+            f"/api/chat/workspaces/{workspace['id']}",
+            json={"title": "新名称", "pinned": True},
+        )
+        pinned = client.patch(
+            "/api/chat/sessions/web:managed",
+            json={"pinned": True},
+        )
+        opened = client.post(f"/api/chat/workspaces/{workspace['id']}/open")
+
+    assert updated.status_code == 200
+    assert updated.json()["title"] == "新名称"
+    assert updated.json()["pinned_at"] is not None
+    assert pinned.status_code == 200
+    assert pinned.json()["pinned_at"] is not None
+    assert opened.status_code == 204
+    assert picker.opened == [project.resolve()]
 
 
 def test_chat_api_lists_sessions_and_messages(tmp_path: Path) -> None:

--- a/tests/unit/bootstrap/test_chat_api.py
+++ b/tests/unit/bootstrap/test_chat_api.py
@@ -65,6 +65,59 @@ def test_chat_api_lists_sessions_and_messages(tmp_path: Path) -> None:
     assert not any(key.startswith("llm_") for key in messages["items"][0])
 
 
+def test_workspace_api_and_session_sandbox_closed_loop(tmp_path: Path) -> None:
+    client, runtime = _client(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with client:
+        registered = client.post(
+            "/api/chat/workspaces",
+            json={"path": str(project), "title": "Bean 项目"},
+        )
+        assert registered.status_code == 201
+        workspace = registered.json()
+        assert workspace["canonical_path"] == str(project.resolve())
+        assert workspace["valid"] is True
+        assert client.get("/api/chat/workspaces").json()["items"] == [workspace]
+
+        with client.websocket_connect("/ws") as websocket:
+            websocket.send_json({
+                "type": "session.create",
+                "request_id": "create-sandbox",
+                "workspace_id": workspace["id"],
+                "sandbox_mode": "workspace-write",
+            })
+            created = websocket.receive_json()
+            snapshot_frame = websocket.receive_json()
+
+        assert created["type"] == "session.created"
+        assert snapshot_frame["type"] == "sandbox.updated"
+        assert snapshot_frame["sandbox"]["workspace_id"] == workspace["id"]
+        assert snapshot_frame["sandbox"]["sandbox_mode"] == "workspace-write"
+        session_id = created["session_id"]
+        assert client.get(
+            f"/api/chat/sessions/{session_id}/sandbox"
+        ).json()["workspace_path"] == str(project.resolve())
+
+        removed = client.delete(f"/api/chat/workspaces/{workspace['id']}")
+        assert removed.status_code == 204
+        detached = client.get(
+            f"/api/chat/sessions/{session_id}/sandbox"
+        ).json()
+        assert detached["workspace_id"] is None
+        assert detached["sandbox_mode"] == "read-only"
+
+        overlap = client.post(
+            "/api/chat/workspaces",
+            json={"path": str(runtime.workspace)},
+        )
+        assert overlap.status_code == 422
+        assert "数据目录重叠" in overlap.json()["detail"]
+
+    assert project.exists()
+
+
 def test_chat_api_lists_titled_running_session_without_messages(tmp_path: Path) -> None:
     client, runtime = _client(tmp_path)
     runtime.sessions.store.ensure_default_chat_session_title(

--- a/tests/unit/sandbox/test_approval.py
+++ b/tests/unit/sandbox/test_approval.py
@@ -1,0 +1,152 @@
+"""单次越权审批状态机测试。"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from sandbox.approval import ApprovalCoordinator, ApprovalRequest
+from sandbox.errors import ApprovalUnavailable
+
+
+class AuditStore:
+    def __init__(self) -> None:
+        self.created: list[dict[str, object]] = []
+        self.resolved: list[tuple[str, str, str]] = []
+
+    def create_sandbox_approval(self, request: dict[str, object]) -> None:
+        self.created.append(dict(request))
+
+    def resolve_sandbox_approval(
+        self,
+        request_id: str,
+        state: str,
+        decided_at: str,
+    ) -> bool:
+        self.resolved.append((request_id, state, decided_at))
+        return True
+
+
+async def _wait_for_request(items: list[ApprovalRequest]) -> ApprovalRequest:
+    for _ in range(100):
+        if items:
+            return items[0]
+        await asyncio.sleep(0)
+    raise AssertionError("审批请求没有发布")
+
+
+@pytest.mark.asyncio
+async def test_approval_allowed_once_is_bound_and_idempotent() -> None:
+    store = AuditStore()
+    published: list[ApprovalRequest] = []
+
+    async def publish(request: ApprovalRequest) -> None:
+        published.append(request)
+
+    coordinator = ApprovalCoordinator(store, publisher=publish)
+    await coordinator.set_session_available("web:a", True)
+    waiting = asyncio.create_task(coordinator.request(
+        session_id="web:a",
+        turn_id="turn-1",
+        call_id="call-1",
+        tool_name="shell",
+        operation="执行完整 Shell 命令",
+        arguments={"command": "echo ok", "description": "测试"},
+        reason="需要单次授权",
+    ))
+    request = await _wait_for_request(published)
+
+    first, duplicate = await asyncio.gather(
+        coordinator.decide(request.id, "web:a", "allowed-once"),
+        coordinator.decide(request.id, "web:a", "rejected"),
+    )
+
+    assert first == duplicate == await waiting
+    assert first in {"allowed-once", "rejected"}
+    assert len(store.resolved) == 1
+
+
+@pytest.mark.asyncio
+async def test_approval_rejects_when_ui_is_unavailable() -> None:
+    store = AuditStore()
+    coordinator = ApprovalCoordinator(store, publisher=lambda _request: asyncio.sleep(0))
+
+    with pytest.raises(ApprovalUnavailable, match="审批界面"):
+        await coordinator.request(
+            session_id="web:offline",
+            turn_id="turn-1",
+            call_id="call-1",
+            tool_name="write_file",
+            operation="写入文件",
+            arguments={"path": "D:/work/a.txt", "content": "secret"},
+            reason="只读会话",
+        )
+
+    assert store.created[0]["state"] == "unavailable"
+    assert store.created[0]["arguments"] == {
+        "path": "D:/work/a.txt",
+        "content_length": 6,
+    }
+
+
+@pytest.mark.asyncio
+async def test_disconnect_marks_pending_request_unavailable() -> None:
+    store = AuditStore()
+    published: list[ApprovalRequest] = []
+
+    async def publish(request: ApprovalRequest) -> None:
+        published.append(request)
+
+    coordinator = ApprovalCoordinator(store, publisher=publish)
+    await coordinator.set_session_available("web:a", True)
+    waiting = asyncio.create_task(coordinator.request(
+        session_id="web:a",
+        turn_id="turn-1",
+        call_id="call-1",
+        tool_name="edit_file",
+        operation="精确编辑文件",
+        arguments={
+            "path": "D:/work/a.txt",
+            "old_text": "private-before",
+            "new_text": "private-after",
+        },
+        reason="只读会话",
+    ))
+    request = await _wait_for_request(published)
+
+    await coordinator.set_session_available("web:a", False)
+
+    assert await waiting == "unavailable"
+    assert request.arguments == {
+        "path": "D:/work/a.txt",
+        "replace_all": False,
+        "old_text_length": 14,
+        "new_text_length": 13,
+    }
+    assert store.resolved[0][1] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_publisher_failure_fails_closed() -> None:
+    store = AuditStore()
+
+    async def fail(_request: ApprovalRequest) -> None:
+        raise RuntimeError("socket failed")
+
+    coordinator = ApprovalCoordinator(store, publisher=fail)
+    await coordinator.set_session_available("web:a", True)
+
+    with pytest.raises(ApprovalUnavailable, match="发送失败"):
+        await coordinator.request(
+            session_id="web:a",
+            turn_id="turn-1",
+            call_id="call-1",
+            tool_name="shell",
+            operation="执行完整 Shell 命令",
+            arguments={"command": "echo ok"},
+            reason="需要单次授权",
+        )
+
+    assert store.resolved[0][1] == "unavailable"

--- a/tests/unit/sandbox/test_runtime.py
+++ b/tests/unit/sandbox/test_runtime.py
@@ -1,0 +1,174 @@
+"""Windows ACL 沙箱的策略和真实进程边界测试。"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from sandbox.policy import SandboxPolicyResolver
+from sandbox.runtime import SandboxProcessRuntime
+from sandbox.windows.acl import temp_write_sid, workspace_write_sid
+from session.store import SessionStore
+
+
+def test_capability_sids_are_stable_and_domain_separated(tmp_path: Path) -> None:
+    workspace = workspace_write_sid(tmp_path)
+
+    assert workspace == workspace_write_sid(tmp_path / ".")
+    assert workspace.startswith("S-1-4-")
+    assert temp_write_sid(tmp_path) != workspace
+    assert temp_write_sid(tmp_path).endswith("-1")
+
+
+def test_policy_without_workspace_uses_private_temp(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    runtime_root = tmp_path / "runtime-temp"
+    store = SessionStore(data_root / "sessions.db")
+    try:
+        store.create_session("web:empty")
+        resolver = SandboxPolicyResolver(
+            store,
+            data_root=data_root,
+            runtime_temp_root=runtime_root,
+        )
+
+        policy = resolver.resolve("web:empty")
+
+        assert policy.mode == "read-only"
+        assert policy.workspace_path is None
+        assert policy.cwd == policy.temp_dir
+        assert policy.cwd.is_relative_to(runtime_root)
+        assert not policy.cwd.is_relative_to(data_root)
+        resolver.close()
+        assert not runtime_root.exists()
+    finally:
+        store.close()
+
+
+def test_policy_rejects_workspace_overlapping_data_root(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    runtime_root = tmp_path / "runtime-temp"
+    store = SessionStore(data_root / "sessions.db")
+    resolver = SandboxPolicyResolver(
+        store,
+        data_root=data_root,
+        runtime_temp_root=runtime_root,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="数据目录重叠"):
+            resolver.validate_workspace(data_root)
+    finally:
+        resolver.close()
+        store.close()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows ACL 后端只在 Windows 验证")
+@pytest.mark.asyncio
+async def test_windows_runtime_reads_but_read_only_cannot_write_workspace(
+    tmp_path: Path,
+) -> None:
+    data_root = tmp_path / "data"
+    project = tmp_path / "project"
+    runtime_root = tmp_path / "runtime-temp"
+    project.mkdir()
+    store = SessionStore(data_root / "sessions.db")
+    workspace = store.create_workspace(str(project))
+    store.create_session("web:readonly", workspace_id=workspace["id"])
+    resolver = SandboxPolicyResolver(
+        store,
+        data_root=data_root,
+        runtime_temp_root=runtime_root,
+    )
+    runtime = SandboxProcessRuntime(resolver)
+    policy = resolver.resolve("web:readonly")
+    target = project / "blocked.txt"
+    try:
+        readable = await runtime.run(
+            policy,
+            [sys.executable, "-c", "print('sandbox-ok')"],
+        )
+        blocked = await runtime.run(
+            policy,
+            [
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; Path({str(target)!r}).write_text('bad')",
+            ],
+        )
+    finally:
+        await runtime.close()
+        store.close()
+
+    assert readable.exit_code == 0
+    assert readable.stdout.strip() == b"sandbox-ok"
+    assert blocked.exit_code != 0
+    assert not target.exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows ACL 后端只在 Windows 验证")
+@pytest.mark.asyncio
+async def test_windows_runtime_workspace_write_stays_inside_workspace(
+    tmp_path: Path,
+) -> None:
+    data_root = tmp_path / "data"
+    project = tmp_path / "project"
+    outside = tmp_path / "outside"
+    runtime_root = tmp_path / "runtime-temp"
+    project.mkdir()
+    outside.mkdir()
+    existing_file = project / "existing.txt"
+    existing_file.write_text("before", encoding="utf-8")
+    store = SessionStore(data_root / "sessions.db")
+    workspace = store.create_workspace(str(project))
+    store.create_session(
+        "web:writable",
+        workspace_id=workspace["id"],
+        sandbox_mode="workspace-write",
+    )
+    resolver = SandboxPolicyResolver(
+        store,
+        data_root=data_root,
+        runtime_temp_root=runtime_root,
+    )
+    runtime = SandboxProcessRuntime(resolver)
+    policy = resolver.resolve("web:writable")
+    inside_file = project / "inside.txt"
+    outside_file = outside / "outside.txt"
+    try:
+        inside = await runtime.run(
+            policy,
+            [
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; Path({str(inside_file)!r}).write_text('ok')",
+            ],
+        )
+        edited = await runtime.run(
+            policy,
+            [
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; Path({str(existing_file)!r}).write_text('after')",
+            ],
+        )
+        escaped = await runtime.run(
+            policy,
+            [
+                sys.executable,
+                "-c",
+                f"from pathlib import Path; Path({str(outside_file)!r}).write_text('bad')",
+            ],
+        )
+    finally:
+        await runtime.close()
+        store.close()
+
+    assert inside.exit_code == 0
+    assert inside_file.read_text(encoding="utf-8") == "ok"
+    assert edited.exit_code == 0
+    assert existing_file.read_text(encoding="utf-8") == "after"
+    assert escaped.exit_code != 0
+    assert not outside_file.exists()

--- a/tests/unit/sandbox/test_tools.py
+++ b/tests/unit/sandbox/test_tools.py
@@ -1,0 +1,146 @@
+"""文件和 Shell 工具接入真实 Windows 沙箱的闭环测试。"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from sandbox.approval import ApprovalCoordinator, ApprovalRequest
+from sandbox.filesystem import FilesystemMutationBroker
+from sandbox.guard import SandboxGuard
+from sandbox.policy import SandboxPolicyResolver
+from sandbox.runtime import SandboxProcessRuntime
+from session.store import SessionStore
+from tools.filesystem import WriteFileTool
+from tools.shell import ShellTool
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows ACL 后端只在 Windows 验证")
+@pytest.mark.asyncio
+async def test_filesystem_worker_honors_workspace_and_single_use_approval(
+    tmp_path: Path,
+) -> None:
+    data_root = tmp_path / "data"
+    project = tmp_path / "project"
+    outside = tmp_path / "outside"
+    runtime_root = tmp_path / "runtime-temp"
+    project.mkdir()
+    outside.mkdir()
+    store = SessionStore(data_root / "sessions.db")
+    workspace = store.create_workspace(str(project))
+    store.create_session(
+        "web:writable",
+        workspace_id=workspace["id"],
+        sandbox_mode="workspace-write",
+    )
+    store.create_session("web:readonly")
+    resolver = SandboxPolicyResolver(
+        store,
+        data_root=data_root,
+        runtime_temp_root=runtime_root,
+    )
+    runtime = SandboxProcessRuntime(resolver)
+    approvals = ApprovalCoordinator(store)
+    published: list[ApprovalRequest] = []
+
+    async def publish(request: ApprovalRequest) -> None:
+        published.append(request)
+        decision = "allowed-once" if len(published) == 1 else "rejected"
+        await approvals.decide(request.id, request.session_id, decision)
+
+    approvals.set_publisher(publish)
+    await approvals.set_session_available("web:readonly", True)
+    guard = SandboxGuard(resolver, approvals)
+    broker = FilesystemMutationBroker(resolver, runtime)
+    tool = WriteFileTool(sandbox_guard=guard, mutation_broker=broker)
+    try:
+        inside_result = await tool.execute(
+            "inside.txt",
+            "workspace",
+            session_key="web:writable",
+            turn_id="turn-1",
+            call_id="call-inside",
+        )
+        approved_result = await tool.execute(
+            str(outside / "approved.txt"),
+            "private-content",
+            session_key="web:readonly",
+            turn_id="turn-2",
+            call_id="call-approved",
+        )
+        rejected_result = await tool.execute(
+            str(outside / "rejected.txt"),
+            "blocked-content",
+            session_key="web:readonly",
+            turn_id="turn-2",
+            call_id="call-rejected",
+        )
+    finally:
+        await approvals.close()
+        await runtime.close()
+        store.close()
+
+    assert "已写入" in inside_result
+    assert (project / "inside.txt").read_text(encoding="utf-8") == "workspace"
+    assert "已写入" in approved_result
+    assert (outside / "approved.txt").read_text(encoding="utf-8") == "private-content"
+    assert "用户拒绝" in rejected_result
+    assert not (outside / "rejected.txt").exists()
+    assert len(published) == 2
+    assert published[0].arguments == {
+        "path": str(outside / "approved.txt"),
+        "content_length": 15,
+    }
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows ACL 后端只在 Windows 验证")
+@pytest.mark.asyncio
+async def test_shell_retries_exact_command_after_allowed_once(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    outside = tmp_path / "outside"
+    runtime_root = tmp_path / "runtime-temp"
+    outside.mkdir()
+    target = outside / "approved.txt"
+    store = SessionStore(data_root / "sessions.db")
+    store.create_session("web:readonly")
+    resolver = SandboxPolicyResolver(
+        store,
+        data_root=data_root,
+        runtime_temp_root=runtime_root,
+    )
+    runtime = SandboxProcessRuntime(resolver)
+    approvals = ApprovalCoordinator(store)
+    published: list[ApprovalRequest] = []
+
+    async def publish(request: ApprovalRequest) -> None:
+        published.append(request)
+        await approvals.decide(request.id, request.session_id, "allowed-once")
+
+    approvals.set_publisher(publish)
+    await approvals.set_session_available("web:readonly", True)
+    tool = ShellTool(
+        sandbox_guard=SandboxGuard(resolver, approvals),
+        sandbox_runtime=runtime,
+    )
+    command = f'echo approved>"{target}"'
+    try:
+        raw_result = await tool.execute(
+            command=command,
+            description="写入外部文件",
+            session_key="web:readonly",
+            turn_id="turn-1",
+            call_id="call-1",
+        )
+    finally:
+        await approvals.close()
+        await runtime.close()
+        store.close()
+
+    result = json.loads(raw_result)
+    assert result["exit_code"] == 0
+    assert target.read_text(encoding="utf-8").strip() == "approved"
+    assert len(published) == 1
+    assert published[0].arguments["command"] == command

--- a/tests/unit/session/test_store.py
+++ b/tests/unit/session/test_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 from collections.abc import AsyncIterator
 from pathlib import Path
 
@@ -1058,3 +1059,103 @@ def test_session_usage_is_idempotent_and_aggregated(store: SessionStore) -> None
     assert second["total_input_tokens"] == 1_060
     assert second["total_output_tokens"] == 50
     assert second["cache_hit_rate"] == pytest.approx(880 / 1060)
+
+
+def test_workspace_binding_and_permission_are_persisted(
+    store: SessionStore,
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    workspace = store.create_workspace(str(project), "示例项目")
+    duplicate = store.create_workspace(str(project / "."), "不会覆盖")
+
+    session = store.create_session(
+        "web:sandbox",
+        workspace_id=workspace["id"],
+        sandbox_mode="workspace-write",
+    )
+    sandbox = store.get_session_sandbox("web:sandbox")
+
+    assert duplicate["id"] == workspace["id"]
+    assert session["workspace_id"] == workspace["id"]
+    assert sandbox is not None
+    assert sandbox["workspace_path"] == str(project.resolve())
+    assert sandbox["sandbox_mode"] == "workspace-write"
+    assert sandbox["workspace_valid"] is True
+
+
+def test_workspace_write_requires_workspace_and_started_session_cannot_rebind(
+    store: SessionStore,
+    tmp_path: Path,
+) -> None:
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first = store.create_workspace(str(first_dir))
+    second = store.create_workspace(str(second_dir))
+    store.create_session("web:fixed", workspace_id=first["id"])
+
+    with pytest.raises(ValueError, match="没有工作目录"):
+        store.create_session("web:no-workspace", sandbox_mode="workspace-write")
+
+    store.add_message(NewMessage(session_key="web:fixed", role="user", content="开始"))
+    with pytest.raises(ValueError, match="不能切换工作目录"):
+        store.set_session_workspace("web:fixed", second["id"])
+
+
+def test_deleting_workspace_detaches_sessions_without_deleting_directory(
+    store: SessionStore,
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "kept-project"
+    project.mkdir()
+    marker = project / "kept.txt"
+    marker.write_text("保留", encoding="utf-8")
+    workspace = store.create_workspace(str(project))
+    store.create_session(
+        "web:detach",
+        workspace_id=workspace["id"],
+        sandbox_mode="workspace-write",
+    )
+
+    assert store.delete_workspace(workspace["id"]) is True
+    sandbox = store.get_session_sandbox("web:detach")
+
+    assert marker.read_text(encoding="utf-8") == "保留"
+    assert sandbox is not None
+    assert sandbox["workspace_id"] is None
+    assert sandbox["sandbox_mode"] == "read-only"
+
+
+def test_existing_sessions_database_is_migrated_to_read_only(tmp_path: Path) -> None:
+    db_path = tmp_path / "legacy.db"
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        """
+        CREATE TABLE sessions (
+            key TEXT PRIMARY KEY,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            last_consolidated INTEGER NOT NULL DEFAULT 0,
+            next_seq INTEGER NOT NULL DEFAULT 0,
+            metadata TEXT NOT NULL DEFAULT '{}'
+        )
+        """
+    )
+    connection.execute(
+        "INSERT INTO sessions VALUES ('web:legacy', 'now', 'now', 0, 0, '{}')"
+    )
+    connection.commit()
+    connection.close()
+
+    migrated = SessionStore(db_path)
+    try:
+        sandbox = migrated.get_session_sandbox("web:legacy")
+    finally:
+        migrated.close()
+
+    assert sandbox is not None
+    assert sandbox["workspace_id"] is None
+    assert sandbox["sandbox_mode"] == "read-only"

--- a/tests/unit/session/test_store.py
+++ b/tests/unit/session/test_store.py
@@ -794,7 +794,7 @@ async def test_cursor_defaults_to_zero_and_can_advance(store: SessionStore) -> N
     assert store.get_cursor("web:chat-1") == 0
 
 
-def test_list_chat_sessions_uses_first_user_time_for_display_and_order(
+def test_list_chat_sessions_uses_first_user_time_and_latest_activity_order(
     store: SessionStore,
 ) -> None:
     store.create_session("web:empty")
@@ -826,11 +826,12 @@ def test_list_chat_sessions_uses_first_user_time_for_display_and_order(
     items, total = store.list_chat_sessions(channel="web", limit=20, offset=0)
 
     assert total == 2
-    assert [item["key"] for item in items] == ["web:newer", "web:older"]
-    assert items[0]["created_at"] == "2026-07-18T11:00:00+08:00"
-    assert items[1]["created_at"] == "2026-07-18T10:00:00+08:00"
-    assert items[1]["message_count"] == 2
-    assert items[0]["first_message_content"] == "较晚创建的问题"
+    assert [item["key"] for item in items] == ["web:older", "web:newer"]
+    assert items[0]["created_at"] == "2026-07-18T10:00:00+08:00"
+    assert items[0]["last_activity_at"] == "2026-07-18T12:00:00+08:00"
+    assert items[0]["message_count"] == 2
+    assert items[1]["created_at"] == "2026-07-18T11:00:00+08:00"
+    assert items[1]["first_message_content"] == "较晚创建的问题"
 
 
 def test_update_chat_session_title_persists_metadata_and_list_value(store: SessionStore) -> None:
@@ -1083,6 +1084,95 @@ def test_workspace_binding_and_permission_are_persisted(
     assert sandbox["workspace_path"] == str(project.resolve())
     assert sandbox["sandbox_mode"] == "workspace-write"
     assert sandbox["workspace_valid"] is True
+
+
+def test_workspace_pin_order_is_stable_and_unpin_restores_created_order(
+    store: SessionStore,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = {"value": "2026-09-03T10:00:00+08:00"}
+    monkeypatch.setattr("session.store._now_iso", lambda: clock["value"])
+    first_dir = tmp_path / "first-project"
+    second_dir = tmp_path / "second-project"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first = store.create_workspace(str(first_dir), "先创建")
+    clock["value"] = "2026-09-03T11:00:00+08:00"
+    second = store.create_workspace(str(second_dir), "后创建")
+
+    assert [item["id"] for item in store.list_workspaces()] == [second["id"], first["id"]]
+
+    clock["value"] = "2026-09-03T12:00:00+08:00"
+    pinned_second = store.update_workspace(second["id"], pinned=True)
+    clock["value"] = "2026-09-03T13:00:00+08:00"
+    store.update_workspace(first["id"], pinned=True)
+    clock["value"] = "2026-09-03T14:00:00+08:00"
+    repeated = store.update_workspace(second["id"], pinned=True)
+
+    assert pinned_second is not None and repeated is not None
+    assert repeated["pinned_at"] == pinned_second["pinned_at"]
+    assert [item["id"] for item in store.list_workspaces()] == [second["id"], first["id"]]
+
+    store.update_workspace(second["id"], pinned=False)
+    ordered = store.list_workspaces()
+    assert [item["id"] for item in ordered] == [first["id"], second["id"]]
+    assert ordered[1]["created_at"] == "2026-09-03T11:00:00+08:00"
+
+
+def test_session_pin_and_non_conversation_updates_preserve_activity_time(
+    store: SessionStore,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = {"value": "2026-09-03T10:00:00+08:00"}
+    monkeypatch.setattr("session.store._now_iso", lambda: clock["value"])
+    project = tmp_path / "activity-project"
+    project.mkdir()
+    workspace = store.create_workspace(str(project))
+    store.create_session("web:first", workspace_id=workspace["id"])
+    store.create_session("web:second", workspace_id=workspace["id"])
+    store.add_message(NewMessage(
+        session_key="web:first",
+        role="user",
+        content="first",
+        timestamp="2026-09-03T11:00:00+08:00",
+    ))
+    store.add_message(NewMessage(
+        session_key="web:second",
+        role="user",
+        content="second",
+        timestamp="2026-09-03T12:00:00+08:00",
+    ))
+
+    activity = store.get_session_meta("web:first")["last_activity_at"]
+    clock["value"] = "2026-09-03T13:00:00+08:00"
+    store.update_chat_session_title("web:first", "重命名")
+    store.update_session_sandbox_mode("web:first", "workspace-write")
+    pinned = store.set_chat_session_pinned("web:first", True)
+    clock["value"] = "2026-09-03T14:00:00+08:00"
+    repeated = store.set_chat_session_pinned("web:first", True)
+
+    assert pinned is not None and repeated is not None
+    assert repeated["pinned_at"] == pinned["pinned_at"]
+    assert repeated["last_activity_at"] == activity
+    assert [item["key"] for item in store.list_chat_sessions()[0]] == [
+        "web:first",
+        "web:second",
+    ]
+
+    store.set_chat_session_pinned("web:first", False)
+    assert [item["key"] for item in store.list_chat_sessions()[0]] == [
+        "web:second",
+        "web:first",
+    ]
+
+
+def test_recent_session_cannot_be_pinned(store: SessionStore) -> None:
+    store.create_session("web:recent")
+
+    with pytest.raises(ValueError, match="最近会话不能置顶"):
+        store.set_chat_session_pinned("web:recent", True)
 
 
 def test_workspace_write_requires_workspace_and_started_session_cannot_rebind(

--- a/tools/filesystem.py
+++ b/tools/filesystem.py
@@ -12,6 +12,9 @@ import os
 from pathlib import Path
 from typing import Any, Awaitable, Callable, TypeVar
 
+from sandbox.errors import SandboxError
+from sandbox.filesystem import FilesystemMutationBroker
+from sandbox.guard import SandboxGuard, resolve_tool_target
 from tools.base import Tool, ToolResult
 
 _READ_MAX_LINES = 400
@@ -272,10 +275,12 @@ class ReadFileTool(Tool):
         allowed_dir: Path | None = None,
         multimodal: bool = True,
         vl_available: bool = False,
+        sandbox_guard: SandboxGuard | None = None,
     ) -> None:
         self._allowed_dir = allowed_dir
         self._multimodal = multimodal
         self._vl_available = vl_available
+        self._sandbox_guard = sandbox_guard
 
     @property
     def name(self) -> str:
@@ -322,7 +327,14 @@ class ReadFileTool(Tool):
         raw_limit = kwargs.get("limit")
         limit = int(raw_limit) if raw_limit is not None else None
         try:
-            file_path = _resolve_path(path, self._allowed_dir)
+            session_key = str(kwargs.get("session_key") or "")
+            if self._sandbox_guard is not None and not session_key:
+                raise SandboxError("缺少会话身份，已拒绝文件读取")
+            file_path = (
+                resolve_tool_target(path, self._sandbox_guard.policy(session_key))
+                if self._sandbox_guard is not None and session_key
+                else _resolve_path(path, self._allowed_dir)
+            )
             if not file_path.exists():
                 return f"错误：文件不存在：{path}"
             if not file_path.is_file():
@@ -392,8 +404,16 @@ class ReadFileTool(Tool):
 class WriteFileTool(Tool):
     """完整覆盖写入文本文件，并自动创建父目录。"""
 
-    def __init__(self, allowed_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        allowed_dir: Path | None = None,
+        *,
+        sandbox_guard: SandboxGuard | None = None,
+        mutation_broker: FilesystemMutationBroker | None = None,
+    ) -> None:
         self._allowed_dir = allowed_dir
+        self._sandbox_guard = sandbox_guard
+        self._mutation_broker = mutation_broker
 
     @property
     def name(self) -> str:
@@ -423,6 +443,27 @@ class WriteFileTool(Tool):
 
     async def execute(self, path: str, content: str, **kwargs: Any) -> str:
         try:
+            session_key = str(kwargs.get("session_key") or "")
+            if self._sandbox_guard is not None and not session_key:
+                raise SandboxError("缺少会话身份，已拒绝文件写入")
+            if self._sandbox_guard is not None and self._mutation_broker is not None and session_key:
+                policy = self._sandbox_guard.policy(session_key)
+                target = resolve_tool_target(path, policy)
+                authorized = await self._sandbox_guard.authorize_file_mutation(
+                    session_key=session_key,
+                    turn_id=str(kwargs.get("turn_id") or ""),
+                    call_id=str(kwargs.get("call_id") or ""),
+                    tool_name=self.name,
+                    arguments={"path": path, "content": content},
+                    target=target,
+                    operation="完整写入文件",
+                )
+                return await self._mutation_broker.execute(
+                    session_key=session_key,
+                    operation=self.name,
+                    arguments={"path": path, "content": content},
+                    execution_mode=authorized.mode,
+                )
             file_path = _resolve_path(path, self._allowed_dir)
 
             async def write() -> str:
@@ -433,7 +474,7 @@ class WriteFileTool(Tool):
                 return f"已写入 {len(content)} 字节到 {path}"
 
             return await _run_with_file_mutation_lock(file_path, write)
-        except PermissionError as error:
+        except (PermissionError, SandboxError) as error:
             return f"错误：{error}"
         except Exception as error:
             return f"写入文件失败：{error}"
@@ -442,8 +483,16 @@ class WriteFileTool(Tool):
 class EditFileTool(Tool):
     """精确替换文件文本，并返回可审查的 unified diff。"""
 
-    def __init__(self, allowed_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        allowed_dir: Path | None = None,
+        *,
+        sandbox_guard: SandboxGuard | None = None,
+        mutation_broker: FilesystemMutationBroker | None = None,
+    ) -> None:
         self._allowed_dir = allowed_dir
+        self._sandbox_guard = sandbox_guard
+        self._mutation_broker = mutation_broker
 
     @property
     def name(self) -> str:
@@ -491,6 +540,33 @@ class EditFileTool(Tool):
     ) -> str:
         replace_all = bool(kwargs.get("replace_all", False))
         try:
+            session_key = str(kwargs.get("session_key") or "")
+            if self._sandbox_guard is not None and not session_key:
+                raise SandboxError("缺少会话身份，已拒绝文件编辑")
+            if self._sandbox_guard is not None and self._mutation_broker is not None and session_key:
+                policy = self._sandbox_guard.policy(session_key)
+                target = resolve_tool_target(path, policy)
+                arguments = {
+                    "path": path,
+                    "old_text": old_text,
+                    "new_text": new_text,
+                    "replace_all": replace_all,
+                }
+                authorized = await self._sandbox_guard.authorize_file_mutation(
+                    session_key=session_key,
+                    turn_id=str(kwargs.get("turn_id") or ""),
+                    call_id=str(kwargs.get("call_id") or ""),
+                    tool_name=self.name,
+                    arguments=arguments,
+                    target=target,
+                    operation="精确编辑文件",
+                )
+                return await self._mutation_broker.execute(
+                    session_key=session_key,
+                    operation=self.name,
+                    arguments=arguments,
+                    execution_mode=authorized.mode,
+                )
             file_path = _resolve_path(path, self._allowed_dir)
 
             async def edit() -> str:
@@ -531,7 +607,7 @@ class EditFileTool(Tool):
                 return f"已成功编辑 {path}（替换 {replaced_count} 处）"
 
             return await _run_with_file_mutation_lock(file_path, edit)
-        except PermissionError as error:
+        except (PermissionError, SandboxError) as error:
             return f"错误：{error}"
         except Exception as error:
             return f"编辑文件失败：{error}"
@@ -540,8 +616,14 @@ class EditFileTool(Tool):
 class ListDirTool(Tool):
     """按名称排序列出指定目录的直接子项。"""
 
-    def __init__(self, allowed_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        allowed_dir: Path | None = None,
+        *,
+        sandbox_guard: SandboxGuard | None = None,
+    ) -> None:
         self._allowed_dir = allowed_dir
+        self._sandbox_guard = sandbox_guard
 
     @property
     def name(self) -> str:
@@ -563,7 +645,14 @@ class ListDirTool(Tool):
 
     async def execute(self, path: str, **kwargs: Any) -> str:
         try:
-            directory = _resolve_path(path, self._allowed_dir)
+            session_key = str(kwargs.get("session_key") or "")
+            if self._sandbox_guard is not None and not session_key:
+                raise SandboxError("缺少会话身份，已拒绝目录读取")
+            directory = (
+                resolve_tool_target(path, self._sandbox_guard.policy(session_key))
+                if self._sandbox_guard is not None and session_key
+                else _resolve_path(path, self._allowed_dir)
+            )
             if not directory.exists():
                 return f"错误：目录不存在：{path}"
             if not directory.is_dir():

--- a/tools/registration.py
+++ b/tools/registration.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING, Protocol
 
 from memory.contracts import MemoryRetrievalApi, MemoryToolProfile, MemoryWriteApi
 from session.store import SessionStore
+from sandbox.filesystem import FilesystemMutationBroker
+from sandbox.guard import SandboxGuard
+from sandbox.runtime import SandboxProcessRuntime
 from tools.forget_memory import ForgetMemoryTool
 from tools.filesystem import EditFileTool, ListDirTool, ReadFileTool, WriteFileTool
 from tools.memorize import MemorizeTool
@@ -37,6 +40,8 @@ def register_filesystem_tools(
     multimodal: bool,
     vl_provider: LLMProvider | None = None,
     vl_model: str = "",
+    sandbox_guard: SandboxGuard | None = None,
+    mutation_broker: FilesystemMutationBroker | None = None,
 ) -> ToolRegistry:
     """注册文件工具，并按主模型能力决定是否增加独立视觉工具。"""
 
@@ -47,11 +52,26 @@ def register_filesystem_tools(
             allowed_dir=None,
             multimodal=multimodal,
             vl_available=vl_available,
+            sandbox_guard=sandbox_guard,
         )
     )
-    registry.register(WriteFileTool(allowed_dir))
-    registry.register(EditFileTool(allowed_dir))
-    registry.register(ListDirTool(allowed_dir))
+    registry.register(
+        WriteFileTool(
+            allowed_dir,
+            sandbox_guard=sandbox_guard,
+            mutation_broker=mutation_broker,
+        ),
+        risk="write",
+    )
+    registry.register(
+        EditFileTool(
+            allowed_dir,
+            sandbox_guard=sandbox_guard,
+            mutation_broker=mutation_broker,
+        ),
+        risk="write",
+    )
+    registry.register(ListDirTool(allowed_dir, sandbox_guard=sandbox_guard))
     if vl_available:
         # Channel 上传可能落在 workspace/uploads 或系统临时目录，
         # 它们不一定属于 agent.workdir。视觉工具因此不继承普通文件工具的路径根
@@ -73,6 +93,9 @@ def register_all(
     session_store: SessionStore | None = None,
     memory_engine: MemoryToolsApi | None = None,
     skills: SkillsLoader | None = None,
+    sandbox_guard: SandboxGuard | None = None,
+    sandbox_runtime: SandboxProcessRuntime | None = None,
+    mutation_broker: FilesystemMutationBroker | None = None,
 ) -> ToolRegistry:
     """注册当前依赖实际支持的全部内置工具。"""
 
@@ -82,6 +105,8 @@ def register_all(
             allow_network=allow_shell_network,
             working_dir=allowed_dir,
             restricted_dir=allowed_dir,
+            sandbox_guard=sandbox_guard,
+            sandbox_runtime=sandbox_runtime,
         )
     )
     register_filesystem_tools(
@@ -90,6 +115,8 @@ def register_all(
         multimodal=multimodal,
         vl_provider=vl_provider,
         vl_model=vl_model,
+        sandbox_guard=sandbox_guard,
+        mutation_broker=mutation_broker,
     )
     registry.register(WebSearchTool(client=search_client))
     registry.register(WebFetchTool(client=fetch_client))

--- a/tools/shell.py
+++ b/tools/shell.py
@@ -15,6 +15,10 @@ from pathlib import Path, PureWindowsPath
 from typing import Any
 from urllib.parse import urlparse
 
+from sandbox.errors import SandboxError
+from sandbox.guard import SandboxGuard
+from sandbox.runtime import SandboxProcessRuntime
+from sandbox.shell import SandboxShellBroker
 from tools.base import Tool
 
 _DEFAULT_TIMEOUT = 60
@@ -244,10 +248,19 @@ class ShellTool(Tool):
         allow_network: bool = True,
         working_dir: Path | None = None,
         restricted_dir: Path | None = None,
+        sandbox_guard: SandboxGuard | None = None,
+        sandbox_runtime: SandboxProcessRuntime | None = None,
     ) -> None:
         self._allow_network = allow_network
         self._working_dir = working_dir
         self._restricted_dir = restricted_dir.resolve() if restricted_dir else None
+        self._sandbox_guard = sandbox_guard
+        self._sandbox_runtime = sandbox_runtime
+        self._sandbox_shell = (
+            SandboxShellBroker(sandbox_runtime)
+            if sandbox_runtime is not None
+            else None
+        )
 
     @property
     def description(self) -> str:
@@ -284,9 +297,20 @@ class ShellTool(Tool):
         timeout = min(int(kwargs.get("timeout", _DEFAULT_TIMEOUT)), _MAX_TIMEOUT)
         if not command:
             return _err("命令不能为空")
-        cwd = self._working_dir
+        session_key = str(kwargs.get("session_key") or "")
+        turn_id = str(kwargs.get("turn_id") or "")
+        call_id = str(kwargs.get("call_id") or "")
+        if self._sandbox_guard is not None and not session_key:
+            return _err("缺少会话身份，已拒绝 Shell 执行")
+        policy = (
+            self._sandbox_guard.policy(session_key)
+            if self._sandbox_guard is not None and session_key
+            else None
+        )
+        cwd = policy.cwd if policy is not None else self._working_dir
         if kwargs.get("cwd") not in (None, ""):
-            cwd = Path(str(kwargs["cwd"])).expanduser()
+            candidate = Path(str(kwargs["cwd"])).expanduser()
+            cwd = ((policy.cwd / candidate) if policy is not None and not candidate.is_absolute() else candidate).resolve()
         if self._restricted_dir is not None and cwd is None:
             cwd = self._restricted_dir
 
@@ -300,36 +324,81 @@ class ShellTool(Tool):
         validation_error = _validate_command(
             command,
             allow_network=self._allow_network,
-            restricted_dir=self._restricted_dir,
+            # Windows ACL 是生产执行边界；旧的字符串过滤只为未注入 Runtime 的
+            # 独立工具调用保留，避免两套策略互相产生假授权。
+            restricted_dir=(None if policy is not None else self._restricted_dir),
             cwd=cwd,
         )
         if validation_error:
             return _err(validation_error)
 
         start = time.monotonic()
-        process = await asyncio.create_subprocess_shell(
-            command,
-            **_subprocess_options(cwd, os.environ.copy()),
-        )
-        interrupted = False
         try:
-            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
-        except asyncio.TimeoutError:
-            interrupted = True
-            try:
-                _kill_process_tree(process)
-            except (ProcessLookupError, PermissionError):
-                pass
-            stdout, stderr = await process.communicate()
-        except asyncio.CancelledError:
-            try:
-                _kill_process_tree(process)
-            except (ProcessLookupError, PermissionError):
-                pass
-            raise
+            if policy is not None and self._sandbox_shell is not None:
+                if cwd is None:
+                    return _err("沙箱 Shell 缺少工作目录")
+                run = await self._sandbox_shell.execute(
+                    policy,
+                    command,
+                    cwd=cwd,
+                    timeout=timeout,
+                )
+                stdout, stderr = run.stdout, run.stderr
+                interrupted = run.interrupted
+                exit_code = run.exit_code
+                if (
+                    exit_code != 0
+                    and policy.mode != "danger-full-access"
+                    and _looks_access_denied(stdout, stderr)
+                    and self._sandbox_guard is not None
+                ):
+                    authorized = await self._sandbox_guard.authorize_shell_retry(
+                        policy=policy,
+                        turn_id=turn_id,
+                        call_id=call_id,
+                        arguments={
+                            "command": command,
+                            "description": description,
+                            "timeout": timeout,
+                            **({"cwd": str(cwd)} if cwd is not None else {}),
+                        },
+                    )
+                    run = await self._sandbox_shell.execute(
+                        policy,
+                        command,
+                        cwd=cwd,
+                        timeout=timeout,
+                        execution_mode=authorized.mode,
+                    )
+                    stdout, stderr = run.stdout, run.stderr
+                    interrupted = run.interrupted
+                    exit_code = run.exit_code
+            else:
+                process = await asyncio.create_subprocess_shell(
+                    command,
+                    **_subprocess_options(cwd, os.environ.copy()),
+                )
+                interrupted = False
+                try:
+                    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    interrupted = True
+                    try:
+                        _kill_process_tree(process)
+                    except (ProcessLookupError, PermissionError):
+                        pass
+                    stdout, stderr = await process.communicate()
+                except asyncio.CancelledError:
+                    try:
+                        _kill_process_tree(process)
+                    except (ProcessLookupError, PermissionError):
+                        pass
+                    raise
+                exit_code = -1 if interrupted else (process.returncode or 0)
+        except SandboxError as error:
+            return _err(str(error))
 
-        output = stdout.decode(errors="replace") + stderr.decode(errors="replace")
-        exit_code = -1 if interrupted else (process.returncode or 0)
+        output = _decode_process_output(stdout) + _decode_process_output(stderr)
         if not output:
             output = "（无输出）"
         elif exit_code != 0 and not interrupted:
@@ -359,6 +428,30 @@ class ShellTool(Tool):
             },
             ensure_ascii=False,
         )
+
+
+def _looks_access_denied(stdout: bytes, stderr: bytes) -> bool:
+    text = (_decode_process_output(stdout) + "\n" + _decode_process_output(stderr)).casefold()
+    return any(
+        marker in text
+        for marker in (
+            "access is denied",
+            "access denied",
+            "permission denied",
+            "拒绝访问",
+        )
+    )
+
+
+def _decode_process_output(content: bytes) -> str:
+    """兼容 UTF-8 工具与跟随 Windows 当前代码页的 cmd.exe 输出。"""
+
+    for encoding in (("utf-8", "mbcs") if _IS_WINDOWS else ("utf-8",)):
+        try:
+            return content.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return content.decode("utf-8", errors="replace")
 
 
 __all__ = ["ShellTool"]


### PR DESCRIPTION
变更说明
- 建立工作目录与会话权限持久化，支持只读、工作区写入和完全访问三档权限。
- 接入 Windows ACL、Restricted Token 和 Job Object 沙箱，限制 Shell 与文件系统写入范围。
- 增加越权操作的单次授权、拒绝处理及完全访问风险确认。
- 阻止运行中或排队会话切换权限、解绑工作目录等不安全操作。
- 接入 Windows 原生文件夹选择器，并确保选择窗口显示在前台。
- 完善工作目录的注册、重命名、置顶、打开和移除能力。
- 侧栏按“置顶 / 项目 / 最近”分组，支持项目内会话置顶及时间排序。
- 保持会话延迟创建，首次有效发送后才写入数据库。
- 补充 SQLite 幂等迁移及后端、前端和端到端测试。